### PR TITLE
concurrency issues in Test with DirectoryWatcher

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,7 @@ https://medium.com/@itzgeoff/including-react-in-your-spring-boot-maven-build-ae3
  
 https://www.hostingadvice.com/how-to/update-node-js-latest-version/
 
-   nvm install v10.16.3
-   cd src/main/app
-   npm install -g yarn
+    nvm install v10.16.3
+    cd src/main/app
+    npm install -g yarn
  

--- a/src/test/java/de/bonndan/nivio/input/DirectoryWatcherTest.java
+++ b/src/test/java/de/bonndan/nivio/input/DirectoryWatcherTest.java
@@ -40,7 +40,7 @@ class DirectoryWatcherTest {
 
         Thread.sleep(1000);
         Files.write(tempFile.toPath(), "Hallo".getBytes(), StandardOpenOption.CREATE, StandardOpenOption.APPEND, StandardOpenOption.WRITE);
-        Thread.sleep(SystemUtils.IS_OS_MAC_OSX ? 50000 : 1000); //#147
+        Thread.sleep(SystemUtils.IS_OS_LINUX ? 1000 : 50000); //#147
 
         ArgumentCaptor<FSChangeEvent> captor = ArgumentCaptor.forClass(FSChangeEvent.class);
         verify(publisher).publishEvent(captor.capture());

--- a/src/test/java/de/bonndan/nivio/input/DirectoryWatcherTest.java
+++ b/src/test/java/de/bonndan/nivio/input/DirectoryWatcherTest.java
@@ -1,5 +1,6 @@
 package de.bonndan.nivio.input;
 
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -39,7 +40,7 @@ class DirectoryWatcherTest {
 
         Thread.sleep(1000);
         Files.write(tempFile.toPath(), "Hallo".getBytes(), StandardOpenOption.CREATE, StandardOpenOption.APPEND, StandardOpenOption.WRITE);
-        Thread.sleep(50000);
+        Thread.sleep(SystemUtils.IS_OS_MAC_OSX ? 50000 : 1000); //#147
 
         ArgumentCaptor<FSChangeEvent> captor = ArgumentCaptor.forClass(FSChangeEvent.class);
         verify(publisher).publishEvent(captor.capture());

--- a/src/test/java/de/bonndan/nivio/input/DirectoryWatcherTest.java
+++ b/src/test/java/de/bonndan/nivio/input/DirectoryWatcherTest.java
@@ -39,7 +39,7 @@ class DirectoryWatcherTest {
 
         Thread.sleep(1000);
         Files.write(tempFile.toPath(), "Hallo".getBytes(), StandardOpenOption.CREATE, StandardOpenOption.APPEND, StandardOpenOption.WRITE);
-        Thread.sleep(1000);
+        Thread.sleep(50000);
 
         ArgumentCaptor<FSChangeEvent> captor = ArgumentCaptor.forClass(FSChangeEvent.class);
         verify(publisher).publishEvent(captor.capture());


### PR DESCRIPTION
increasing the Thread.sleep() time after changing the file contents allows the application to register the change event (tested on macOS 10.15.4 with openjdk version "11.0.7" 2020-04-14)