### PR TITLE
[#184] fix for broken fqis in svg

### DIFF
--- a/src/main/java/de/bonndan/nivio/output/map/svg/SVGItem.java
+++ b/src/main/java/de/bonndan/nivio/output/map/svg/SVGItem.java
@@ -13,6 +13,11 @@ import java.awt.geom.Point2D;
 
 import static de.bonndan.nivio.output.map.MapFactory.DEFAULT_ICON_SIZE;
 
+/**
+ * A landscape item to be rendered in svg.
+ *
+ *
+ */
 class SVGItem extends Component {
 
     private final String id;
@@ -24,7 +29,7 @@ class SVGItem extends Component {
         this.children = children;
         this.pixel = position;
         this.item = item;
-        this.id = item.getFullyQualifiedIdentifier().toString();
+        this.id = item.getFullyQualifiedIdentifier().jsonValue();
     }
 
     /**

--- a/src/main/java/de/bonndan/nivio/output/map/svg/SVGItemLabel.java
+++ b/src/main/java/de/bonndan/nivio/output/map/svg/SVGItemLabel.java
@@ -45,7 +45,7 @@ class SVGItemLabel extends Component {
 
         ContainerTag g = SvgTagCreator.g(rect, labelText).attr("class", "label");
         g.attr("id", getId());
-        g.attr("data-identifier", item.getFullyQualifiedIdentifier().toString());
+        g.attr("data-identifier", item.getFullyQualifiedIdentifier().jsonValue());
         if (!StringUtils.isEmpty(item.getName()))
             g.attr("data-name", item.getName());
         if (!StringUtils.isEmpty(item.getDescription()))
@@ -64,7 +64,7 @@ class SVGItemLabel extends Component {
     }
 
     private String getId() {
-        return "label_" + item.getFullyQualifiedIdentifier().toString()
+        return "label_" + item.getFullyQualifiedIdentifier().jsonValue()
                 .replace(FullyQualifiedIdentifier.SEPARATOR, "_")
                 .replace(".", "_")
                 .replace(":", "_")

--- a/src/main/java/de/bonndan/nivio/output/map/svg/SVGRelation.java
+++ b/src/main/java/de/bonndan/nivio/output/map/svg/SVGRelation.java
@@ -66,8 +66,8 @@ class SVGRelation extends Component {
     private ContainerTag addAttributes(ContainerTag g, RelationItem<Item> relation) {
         String type = !StringUtils.isEmpty(relation.getType()) ? relation.getType().name() : "-";
         g.attr("data-type", type)
-                .attr("data-source", relation.getSource().getFullyQualifiedIdentifier())
-                .attr("data-target", relation.getTarget().getFullyQualifiedIdentifier());
+                .attr("data-source", relation.getSource().getFullyQualifiedIdentifier().jsonValue())
+                .attr("data-target", relation.getTarget().getFullyQualifiedIdentifier().jsonValue());
 
         return g;
     }

--- a/src/main/java/de/bonndan/nivio/output/map/svg/SvgFactory.java
+++ b/src/main/java/de/bonndan/nivio/output/map/svg/SvgFactory.java
@@ -61,7 +61,7 @@ public class SvgFactory extends Component {
                 i++;
             }
 
-            hex.id = item.getFullyQualifiedIdentifier().toString();
+            hex.id = item.getFullyQualifiedIdentifier().jsonValue();
             vertexHexes.put(item, hex);
             occupied.add(hex);
         });

--- a/src/test/java/de/bonndan/nivio/output/map/svg/SVGItemLabelTest.java
+++ b/src/test/java/de/bonndan/nivio/output/map/svg/SVGItemLabelTest.java
@@ -1,0 +1,30 @@
+package de.bonndan.nivio.output.map.svg;
+
+import de.bonndan.nivio.model.Item;
+import de.bonndan.nivio.model.LandscapeImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SVGItemLabelTest {
+
+    @Test
+    @DisplayName("ensure label uses proper fqi")
+    public void regression184() {
+
+        LandscapeImpl landscape = new LandscapeImpl();
+        landscape.setIdentifier("l1");
+
+        // item has no group
+        Item foo = new Item();
+        foo.setIdentifier("foo");
+        foo.setLandscape(landscape);
+
+
+        SVGItemLabel svgItemLabel = new SVGItemLabel(foo);
+        String render = svgItemLabel.render().render();
+        assertTrue(render.contains("l1/common/foo"));
+        assertFalse(render.contains("l1//foo"));
+    }
+}

--- a/src/test/java/de/bonndan/nivio/output/map/svg/SVGItemTest.java
+++ b/src/test/java/de/bonndan/nivio/output/map/svg/SVGItemTest.java
@@ -1,0 +1,28 @@
+package de.bonndan.nivio.output.map.svg;
+
+import de.bonndan.nivio.model.Item;
+import de.bonndan.nivio.model.LandscapeImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.awt.geom.Point2D;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SVGItemTest {
+
+    @Test
+    @DisplayName("ensure item uses proper fqi as id")
+    public void regression184() {
+        LandscapeImpl landscape = new LandscapeImpl();
+        landscape.setIdentifier("l1");
+
+        // item has no group
+        Item foo = new Item();
+        foo.setIdentifier("foo");
+        foo.setLandscape(landscape);
+
+        SVGItem svgItem = new SVGItem(null, foo, new Point2D.Double(1,1));
+        assertTrue( svgItem.render().render().contains("l1/common/foo"));
+    }
+}

--- a/src/test/java/de/bonndan/nivio/output/map/svg/SVGRelationTest.java
+++ b/src/test/java/de/bonndan/nivio/output/map/svg/SVGRelationTest.java
@@ -1,0 +1,43 @@
+package de.bonndan.nivio.output.map.svg;
+
+import de.bonndan.nivio.model.Item;
+import de.bonndan.nivio.model.LandscapeImpl;
+import de.bonndan.nivio.model.Relation;
+import de.bonndan.nivio.model.RelationItem;
+import j2html.tags.DomContent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SVGRelationTest {
+
+    @Test
+    @DisplayName("items without groups use proper fqi")
+    public void regression184() {
+
+        LandscapeImpl landscape = new LandscapeImpl();
+        landscape.setIdentifier("l1");
+
+        //both items have no group
+        Item foo = new Item();
+        foo.setIdentifier("foo");
+        foo.setLandscape(landscape);
+
+        Item bar = new Item();
+        bar.setIdentifier("bar");
+        bar.setLandscape(landscape);
+
+        RelationItem<Item> itemRelationItem = new Relation(foo, bar);
+        SVGRelation svgRelation = new SVGRelation(new HexPath(new ArrayList<>()), "", itemRelationItem);
+        DomContent render = svgRelation.render();
+        String render1 = render.render();
+        assertTrue(render1.contains("l1/common/foo"));
+        assertFalse(render1.contains("l1//foo"));
+        assertTrue(render1.contains("l1/common/bar"));
+        assertFalse(render1.contains("l1//bar"));
+    }
+
+}


### PR DESCRIPTION
This replaces FQI.toString with an already existing safe method to get the string representations.