### PR TITLE
[#160] Fix link to external stylesheet in DEMO mode

### DIFF
--- a/docs/source/magic.rst
+++ b/docs/source/magic.rst
@@ -90,7 +90,7 @@ For instance
           nivio.link.wiki: http://mywiki.acme.com
 
 
-will set the related values (here: name and relations). Remember to scape URLs with double quotes.
+will set the related values (here: name and relations). Remember to escape URLs with double quotes.
 
 Labels can be set using docker-compose files, too. However, docker labels not not allow arrays, so use comma separated strings:
 
@@ -118,7 +118,7 @@ are read and assigned as item labels, then examined:
 
 Then the label is examined:
 
-* If the value matches a landscape item identifier, the correspondig item is used as target and detection ends
+* If the value matches a landscape item identifier, the corresponding item is used as target and detection ends
 * In the case of being an URL, the host and name path components are extracted and used as names or identifiers.
 * Otherwise, the **key** of the label is split using the underscore "_" characters and the resulting parts are used as names
 or identifier. For instance FOO_API_URL would look for landscape items like "foo" and "api".

--- a/src/main/java/de/bonndan/nivio/input/FileFetcher.java
+++ b/src/main/java/de/bonndan/nivio/input/FileFetcher.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
@@ -105,8 +106,8 @@ public class FileFetcher {
     @NonNull
     public static String readFile(File source) {
         try {
-            return new String(Files.readAllBytes(Paths.get(source.toURI())));
-        } catch (IOException e) {
+            return Files.readString(Paths.get(source.toURI()), StandardCharsets.UTF_8);
+        } catch (IOException | OutOfMemoryError | SecurityException e) {
             LOGGER.error("Failed to read file " + source.getAbsolutePath(), e);
             throw new ReadingException("Failed to read file " + source.getAbsolutePath(), e);
         }

--- a/src/main/java/de/bonndan/nivio/output/map/svg/MapStyleSheetFactory.java
+++ b/src/main/java/de/bonndan/nivio/output/map/svg/MapStyleSheetFactory.java
@@ -40,13 +40,8 @@ public class MapStyleSheetFactory {
         String mapCss = "";
         processLog.debug("Loading customer stylesheet: " + mapStylesheet);
         try {
-            URL url = new URL(mapStylesheet);
-            if (URLHelper.isLocal(url)) {
-                mapCss = Files.readString(new File(url.toString()).toPath());
-            } else {
-                mapCss = fileFetcher.get(url);
-            }
-        } catch (IOException | ReadingException e ) {
+            mapCss = fileFetcher.get(URLHelper.getURL(mapStylesheet));
+        } catch (ReadingException e ) {
             processLog.warn("Failed to load customer stylesheet " + mapStylesheet + ": " + e.getMessage());
         }
         return mapCss;

--- a/src/test/resources/example/inout.yml
+++ b/src/test/resources/example/inout.yml
@@ -4,7 +4,7 @@ description: Misuses the landscape graph to show the input and output possibilit
 
 config:
   branding:
-    mapStylesheet: https://nivio-demo.herokuapp.com/css/inout.css
+    mapStylesheet: http://localhost:8080/css/inout.css
     mapLogo: https://dedica.team/images/logo_orange_weiss.png
 
 groups:


### PR DESCRIPTION
FileFetcher.readFile: Use Files.readString instead of new String(Files.readAllBytes())

MapStyleSheetFactory.getMapStylesheet: Use URLHelper.getURL to build the css URL

example/inout.yml: use http://localhost:8080/css/inout.css as mapStyleshee

Fix 2 typos in docs/source/magic.rst