### PR TITLE
[#44] Update docker instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -47,7 +47,7 @@ Clone nivio, build and run a Docker image:
     git clone https://github.com/dedica-team/nivio.git && cd nivio
     mvn clean package
     docker build -t nivio:latest .
-    docker run -e SEED=/tmp/inout.yml --mount type=bind,source="$(pwd)"/src/test/resources/example,target=/tmp -p 8080:8080 nivio:latest
+    docker run -e SEED=/tmp/nivio/inout.yml --mount type=bind,source="$(pwd)"/src/test/resources/example,target=/tmp/nivio -p 8080:8080 nivio:latest
     
   then open http://localhost:8080
   
@@ -58,7 +58,7 @@ Clone nivio, build and run a Docker image:
       git clone https://github.com/dedica-team/nivio.git && cd nivio
       mvn clean package
       docker build -t nivio:latest .
-      docker run -e SEED=/tmp/inout.yml --mount type=bind,source=C:\<your>\<path>\<to>\nivio\src\test\resources\example,target=/tmp -p 8080:8080 nivio:latest
+      docker run -e SEED=/tmp/nivio/inout.yml --mount type=bind,source=C:\<your>\<path>\<to>\nivio\src\test\resources\example,target=/tmp/nivio -p 8080:8080 nivio:latest
       
    then open http://localhost:8080
    


### PR DESCRIPTION
Readme: Update docker instructions to use /tmp/nivio instead of /tmp

if we bind `"$(pwd)"/src/test/resources/example` to  `/tmp` all temp files written by the container will end up on the host system in `"$(pwd)"/src/test/resources/example` to prevent this we can use a subdirectory of `/tmp` 

Closes #44 