### PR TITLE
Remove .env and use full qualified domain as default.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -76,5 +76,6 @@ Clone nivio, build and run a Docker image:
   
   You can use your own configuration files, if you add SEED=/path/to/config as an environment variable.
   
+  Open http://localhost:8080
   
-  To start our React frontend, read further into our [Frontend Readme](https://github.com/dedica-team/nivio/tree/develop/src/main/app)
+  If you want to contribute to our frontend, read further into our [Frontend Readme](https://github.com/dedica-team/nivio/tree/develop/src/main/app)

--- a/src/main/app/.env
+++ b/src/main/app/.env
@@ -1,2 +1,0 @@
-REACT_APP_BACKEND_URL=https://nivio-demo.herokuapp.com
-PUBLIC_URL=./

--- a/src/main/app/.env.development
+++ b/src/main/app/.env.development
@@ -2,4 +2,3 @@
 // https://create-react-app.dev/docs/adding-custom-environment-variables/#what-other-env-files-can-be-used
 
 REACT_APP_BACKEND_URL=http://localhost:8080
-PUBLIC_URL=./

--- a/src/main/app/README.md
+++ b/src/main/app/README.md
@@ -4,9 +4,10 @@
 
 1. [Installation & Settings](https://github.com/dedica-team/nivio/blob/develop/src/main/app/README.md#installation-settings)
 2. [Technology used](https://github.com/dedica-team/nivio/blob/develop/src/main/app/README.md#technology-used)
-3. [Styling](https://github.com/dedica-team/nivio/blob/develop/src/main/app/README.md#styling)
-4. [Codeanalysis & Tests](https://github.com/dedica-team/nivio/blob/develop/src/main/app/README.md#Codeanalysis-tests)
-5. [CI/CD](https://github.com/dedica-team/nivio/blob/develop/src/main/app/README.md#cicd)
+3. [Environment Variables](https://github.com/dedica-team/nivio/blob/develop/src/main/app/README.md#environment-variables)
+4. [Styling](https://github.com/dedica-team/nivio/blob/develop/src/main/app/README.md#styling)
+5. [Codeanalysis & Tests](https://github.com/dedica-team/nivio/blob/develop/src/main/app/README.md#Codeanalysis-tests)
+6. [CI/CD](https://github.com/dedica-team/nivio/blob/develop/src/main/app/README.md#cicd)
 
 # Installation & Settings
 
@@ -29,14 +30,7 @@
     git pull
 ```
 
-2. Install node_modules:
-
-```bash
-    cd src/main/app
-    yarn install
-```
-
-3. Start the spring backend in IntelliJ
+2. Start the spring backend in IntelliJ
 
 ```bash
     mvn clean package
@@ -47,7 +41,7 @@ If you want to see the demo you have to set environmental variable in spring boo
 
 ![Spring Config](doc/spring_config.png 'Spring Config')
 
-4. Start nivio frontend
+3. Start nivio frontend
 
 ```bash
    cd src/main/app
@@ -82,6 +76,10 @@ Nivio can be reached at http://localhost:3000
 # Styling
 
 We use [Material-UI](https://material-ui.com/) for most of our styling combined with our own .scss files for clean, easy and less CSS. [Learn More](https://sass-lang.com/)
+
+# Environment Variables
+
+We set our REACT_APP_BACKEND_URL in .env.development to http://localhost:8080, because our frontend now runs on a different port. This way we can use hot reloading from React while developing, because we dont have to rebuild the maven package everytime we change something. If you want to run the frontend app on another port or domain in production, you can create a .env.production file with the same content as .env.development, but change the URL appropriatly.
 
 # Codeanalysis, Formatting & Tests
 

--- a/src/main/app/src/Components/LandscapeComponent/LandscapeMap/LandscapeMap.tsx
+++ b/src/main/app/src/Components/LandscapeComponent/LandscapeMap/LandscapeMap.tsx
@@ -122,7 +122,7 @@ const Landscape: React.FC<Props> = () => {
   };
 
   useEffect(() => {
-    setData(process.env.REACT_APP_BACKEND_URL + '/render/' + identifier + '/map.svg');
+    setData(`${process.env.REACT_APP_BACKEND_URL || ''}'/render/identifier/map.svg`);
   }, [identifier]);
 
   useEffect(() => {

--- a/src/main/app/src/Components/LandscapeComponent/LandscapeMap/LandscapeMap.tsx
+++ b/src/main/app/src/Components/LandscapeComponent/LandscapeMap/LandscapeMap.tsx
@@ -122,7 +122,7 @@ const Landscape: React.FC<Props> = () => {
   };
 
   useEffect(() => {
-    setData(`${process.env.REACT_APP_BACKEND_URL || ''}'/render/identifier/map.svg`);
+    setData(`${process.env.REACT_APP_BACKEND_URL || ''}/render/${identifier}/map.svg`);
   }, [identifier]);
 
   useEffect(() => {

--- a/src/main/app/src/Components/LandscapeComponent/LandscapeOverview/LandscapeOverviewLayout.tsx
+++ b/src/main/app/src/Components/LandscapeComponent/LandscapeOverview/LandscapeOverviewLayout.tsx
@@ -50,12 +50,9 @@ const LandscapeOverviewLayout: React.FC<Props> = ({
               <img
                 className={'preview'}
                 alt={'preview'}
-                src={
-                  process.env.REACT_APP_BACKEND_URL +
-                  '/render/' +
-                  landscape.identifier +
-                  '/graph.png'
-                }
+                src={`${process.env.REACT_APP_BACKEND_URL || ''}/render/${
+                  landscape.identifier
+                }/graph.png`}
                 style={{ maxWidth: 100, float: 'left' }}
               />
             </Button>
@@ -114,9 +111,9 @@ const LandscapeOverviewLayout: React.FC<Props> = ({
               className={'button stackedButton'}
               rel='noopener noreferrer'
               target={'_blank'}
-              href={
-                process.env.REACT_APP_BACKEND_URL + '/render/' + landscape.identifier + '/map.svg'
-              }
+              href={`${process.env.REACT_APP_BACKEND_URL || ''}/render/${
+                landscape.identifier
+              }/map.svg`}
             >
               Printable Graph
             </Button>
@@ -126,9 +123,9 @@ const LandscapeOverviewLayout: React.FC<Props> = ({
               className={'button'}
               rel='noopener noreferrer'
               target={'_blank'}
-              href={
-                process.env.REACT_APP_BACKEND_URL + '/docs/' + landscape.identifier + '/report.html'
-              }
+              href={`${process.env.REACT_APP_BACKEND_URL || ''}/docs/${
+                landscape.identifier
+              }/report.html`}
             >
               Printable Report
             </Button>

--- a/src/main/app/src/Components/LandscapeComponent/LandscapeOverview/LandscapeOverviewLayout.tsx
+++ b/src/main/app/src/Components/LandscapeComponent/LandscapeOverview/LandscapeOverviewLayout.tsx
@@ -35,6 +35,8 @@ const LandscapeOverviewLayout: React.FC<Props> = ({
     range         |   xs   |   sm   |   md   |   lg   |   xl
   */
   let content: string | ReactElement[] = 'Loading landscapes...';
+  const backendUrl = process.env.REACT_APP_BACKEND_URL || '';
+
   if (Array.isArray(landscapes) && landscapes.length) {
     content = landscapes.map((landscape) => {
       let itemCount = 0;
@@ -50,9 +52,7 @@ const LandscapeOverviewLayout: React.FC<Props> = ({
               <img
                 className={'preview'}
                 alt={'preview'}
-                src={`${process.env.REACT_APP_BACKEND_URL || ''}/render/${
-                  landscape.identifier
-                }/graph.png`}
+                src={`${backendUrl}/render/${landscape.identifier}/graph.png`}
                 style={{ maxWidth: 100, float: 'left' }}
               />
             </Button>
@@ -111,9 +111,7 @@ const LandscapeOverviewLayout: React.FC<Props> = ({
               className={'button stackedButton'}
               rel='noopener noreferrer'
               target={'_blank'}
-              href={`${process.env.REACT_APP_BACKEND_URL || ''}/render/${
-                landscape.identifier
-              }/map.svg`}
+              href={`${backendUrl}/render/${landscape.identifier}/map.svg`}
             >
               Printable Graph
             </Button>
@@ -123,9 +121,7 @@ const LandscapeOverviewLayout: React.FC<Props> = ({
               className={'button'}
               rel='noopener noreferrer'
               target={'_blank'}
-              href={`${process.env.REACT_APP_BACKEND_URL || ''}/docs/${
-                landscape.identifier
-              }/report.html`}
+              href={`${backendUrl}/docs/${landscape.identifier}/report.html`}
             >
               Printable Report
             </Button>

--- a/src/main/app/src/utils/API/APIConfig.ts
+++ b/src/main/app/src/utils/API/APIConfig.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
 
 export default axios.create({
-  baseURL: process.env.REACT_APP_BACKEND_URL,
+  baseURL: process.env.REACT_APP_BACKEND_URL || '/',
 });


### PR DESCRIPTION
- Remove public url from .env.development (unnecessary)
- make process.env.REACT_APP_BACKEND_URL optional

We still need REACT_APP_BACKEND_URL for our local development because ports differ, if we start the frontend manually. It can also be used in a .env.production file to set the backend url for another port/domain.

Closes #203 