### PR TITLE
Omit dependency download logs during Maven test run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,5 +58,8 @@ jobs:
           restore-keys: ${{runner.os}}-yarn-
 
       - name: Test with Maven
+        # The logger config ensures that dependency downloads are not logged.
+        # Reference: https://blogs.itemis.com/en/in-a-nutshell-removing-artifact-messages-from-maven-log-output
+        # This is useful as the tests run in fresh containers and, therefore, dependencies are *always* downloaded.
         run: |
-          mvn test --batch-mode --f pom.xml
+          mvn test --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn --f pom.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,4 +58,5 @@ jobs:
           restore-keys: ${{runner.os}}-yarn-
 
       - name: Test with Maven
-        run: mvn test -B --f pom.xml
+        run: |
+          mvn test --batch-mode --f pom.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,4 +61,4 @@ jobs:
         # The logger config ensures that dependency downloads are not logged.
         # Reference: https://blogs.itemis.com/en/in-a-nutshell-removing-artifact-messages-from-maven-log-output
         # This is useful as the tests run in fresh containers and, therefore, dependencies are *always* downloaded.
-        run: mvn test --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn --f pom.xml
+        run: mvn test --batch-mode "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn" --f pom.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,5 +61,4 @@ jobs:
         # The logger config ensures that dependency downloads are not logged.
         # Reference: https://blogs.itemis.com/en/in-a-nutshell-removing-artifact-messages-from-maven-log-output
         # This is useful as the tests run in fresh containers and, therefore, dependencies are *always* downloaded.
-        run: |
-          mvn test --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn --f pom.xml
+        run: mvn test --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn --f pom.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Set up JDK 1.11
         uses: actions/setup-java@v1
         with:


### PR DESCRIPTION
Ensures that the download progress of dependencies is not shown in the GitHub Actions output.

Additionally, both GitHub Actions jobs use the same checkout step version now.