### PR TITLE
fix material-ui-icons install

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -280,6 +280,9 @@
                         <goals>
                             <goal>yarn</goal>
                         </goals>
+                        <configuration>
+                            <arguments>--network-timeout 500000</arguments>
+                        </configuration>
                     </execution>
                     <execution>
                         <id>Run test</id>


### PR DESCRIPTION
fix yarn install timeout
```
[INFO] Running 'yarn ' in /Users/runner/work/nivio/nivio/src/main/app
[INFO] yarn install v1.22.4
[INFO] [1/4] Resolving packages...
[INFO] [2/4] Fetching packages...
[INFO] info There appears to be trouble with your network connection. Retrying...
[INFO] info There appears to be trouble with your network connection. Retrying...
[INFO] info There appears to be trouble with your network connection. Retrying...
[INFO] info There appears to be trouble with your network connection. Retrying...
[INFO] info There appears to be trouble with your network connection. Retrying...
[INFO] info If you think this is a bug, please open a bug report with the information provided in "/Users/runner/work/nivio/nivio/src/main/app/yarn-error.log".
[ERROR] error An unexpected error occurred: "https://registry.yarnpkg.com/@material-ui/icons/-/icons-4.9.1.tgz: ESOCKETTIMEDOUT".
[INFO] info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```


see [github.com/mui-org/material-ui/issues/12432](https://github.com/mui-org/material-ui/issues/12432)