### PR TITLE
Update frontend-maven-plugin to v1.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <frontend-src-dir>${project.basedir}/src/main/app</frontend-src-dir>
         <node.version>v12.18.2</node.version>
         <yarnVersion>v1.22.4</yarnVersion>
-        <frontend-maven-plugin.version>1.7.6</frontend-maven-plugin.version>
+		<frontend-maven-plugin.version>1.10.0</frontend-maven-plugin.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
fix yarn output

old
```
[INFO] --- frontend-maven-plugin:1.7.6:yarn (Run test) @ nivio ---
[INFO] Running 'yarn test' in D:\dev\nivio\src\main\app
[INFO] yarn run v1.22.4
[INFO] $ react-scripts test
[ERROR] PASS src/Components/LandscapeComponent/LandscapeItem/LandscapeItem.test.tsx (9.285s)
```

now
```
[INFO] --- frontend-maven-plugin:1.10.0:yarn (Run test) @ nivio ---
[INFO] Running 'yarn test' in D:\dev\nivio\src\main\app
[INFO] yarn run v1.22.4
[INFO] $ react-scripts test
[INFO] PASS src/Components/LandscapeComponent/LandscapeItem/LandscapeItem.test.tsx (9.56s)
```

