### PR TITLE
260 duplicate items

### DIFF
--- a/src/main/java/de/bonndan/nivio/model/Group.java
+++ b/src/main/java/de/bonndan/nivio/model/Group.java
@@ -98,7 +98,7 @@ public class Group implements GroupItem, Labeled, Assessable {
      * @return immutable copy
      */
     public Set<Item> getItems() {
-        return Set.copyOf(items);
+        return Collections.unmodifiableSet(items);
     }
 
     @Override

--- a/src/main/java/de/bonndan/nivio/model/Group.java
+++ b/src/main/java/de/bonndan/nivio/model/Group.java
@@ -20,7 +20,7 @@ public class Group implements GroupItem, Labeled, Assessable {
      * Items belonging to this group. Order is important for layouting (until items are ordered there).
      */
     private final Set<Item> items = new LinkedHashSet<>();
-    private String identifier;
+    private final String identifier;
     private String owner;
     private String description;
     private String contact;
@@ -29,16 +29,15 @@ public class Group implements GroupItem, Labeled, Assessable {
     private String landscapeIdentifier;
 
     public Group(String identifier) {
-        setIdentifier(identifier);
+        if (StringUtils.isEmpty(identifier)) {
+            throw new IllegalArgumentException("Group identifier must not be empty");
+        }
+        this.identifier = identifier;
     }
 
     @Override
     public String getIdentifier() {
         return identifier;
-    }
-
-    public void setIdentifier(String identifier) {
-        this.identifier = StringUtils.isEmpty(identifier) ? COMMON : identifier;
     }
 
     @Override
@@ -93,8 +92,13 @@ public class Group implements GroupItem, Labeled, Assessable {
         return links;
     }
 
+    /**
+     * Returns an immutable copy of the items.
+     *
+     * @return immutable copy
+     */
     public Set<Item> getItems() {
-        return items;
+        return Set.copyOf(items);
     }
 
     @Override
@@ -141,5 +145,23 @@ public class Group implements GroupItem, Labeled, Assessable {
         return "Group{" +
                 "identifier='" + identifier + '\'' +
                 '}';
+    }
+
+    /**
+     * Adds an item to this group.
+     *
+     * @param item the item to add.
+     * @throws IllegalArgumentException if the item group field mismatches
+     */
+    public void addItem(Item item) {
+        boolean canAdd = item.getGroup() == null || (item.getGroup().equals(identifier));
+
+        if (canAdd) {
+            item.setGroup(identifier);
+            items.add(item);
+            return;
+        }
+
+        throw new IllegalArgumentException(String.format("Item group '%s' cannot be added to group '%s'", item.getGroup(), identifier));
     }
 }

--- a/src/main/java/de/bonndan/nivio/model/Item.java
+++ b/src/main/java/de/bonndan/nivio/model/Item.java
@@ -18,7 +18,7 @@ public class Item implements LandscapeItem, Tagged, Labeled, Assessable {
 
     @NotNull
     @Pattern(regexp = LandscapeItem.IDENTIFIER_VALIDATION)
-    private String identifier;
+    private final String identifier;
 
     @NotNull
     @JsonIgnore
@@ -50,15 +50,16 @@ public class Item implements LandscapeItem, Tagged, Labeled, Assessable {
     private String color;
     private String icon;
 
-    public String getIdentifier() {
-        return identifier;
-    }
-
-    public void setIdentifier(String identifier) {
+    public Item(String group, String identifier) {
+        this.group = group;
         if (StringUtils.isEmpty(identifier)) {
             throw new RuntimeException("Identifier must not be empty");
         }
         this.identifier = identifier.toLowerCase();
+    }
+
+    public String getIdentifier() {
+        return identifier;
     }
 
     @Override
@@ -126,7 +127,15 @@ public class Item implements LandscapeItem, Tagged, Labeled, Assessable {
         return group;
     }
 
-    public void setGroup(String group) {
+    /**
+     * Sets the group name IF not set previously.
+     *
+     * @param group name
+     */
+    void setGroup(String group) {
+        if (this.group != null && group != null && !this.group.equals(group)) {
+            throw new IllegalArgumentException(String.format("A once set item group ('%s') cannot be overwritten with ('%s').", this.group, group));
+        }
         this.group = group;
     }
 
@@ -227,7 +236,7 @@ public class Item implements LandscapeItem, Tagged, Labeled, Assessable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(toString());
+        return Objects.hash(identifier);
     }
 
     /**

--- a/src/main/java/de/bonndan/nivio/model/ItemFactory.java
+++ b/src/main/java/de/bonndan/nivio/model/ItemFactory.java
@@ -17,9 +17,8 @@ public class ItemFactory {
             throw new RuntimeException("landscape item is null");
         }
 
-        Item landscapeItemImpl = new Item();
+        Item landscapeItemImpl = new Item(item.getGroup(), item.getIdentifier());
         landscapeItemImpl.setLandscape(landscape);
-        landscapeItemImpl.setIdentifier(item.getIdentifier());
         assignAll(landscapeItemImpl, item);
         return landscapeItemImpl;
     }

--- a/src/main/java/de/bonndan/nivio/observation/ObserverRegistry.java
+++ b/src/main/java/de/bonndan/nivio/observation/ObserverRegistry.java
@@ -100,7 +100,7 @@ public class ObserverRegistry implements ApplicationListener<ProcessingFinishedE
     /**
      * Polls for changes in landscapes.
      */
-    @Scheduled(fixedDelay = 20000, initialDelay = 5000)
+    @Scheduled(fixedDelayString = "${nivio.pollingMilliseconds}", initialDelay = 5000)
     public void poll() {
         LOGGER.info("Polling {} landscapes for changes.", observerMap.size());
         observerMap.entrySet().parallelStream().forEach(e -> check(e.getValue()));

--- a/src/main/java/de/bonndan/nivio/output/layout/AllGroupsLayout.java
+++ b/src/main/java/de/bonndan/nivio/output/layout/AllGroupsLayout.java
@@ -55,7 +55,7 @@ public class AllGroupsLayout {
         layout.configure(landscape.getConfig().getGroupLayoutConfig());
 
         layout.execute();
-        LOGGER.info("AllGroupsLayout bounds: {}", layout.getBounds());
+        LOGGER.debug("AllGroupsLayout bounds: {}", layout.getBounds());
     }
 
 

--- a/src/main/java/de/bonndan/nivio/output/map/hex/PathFinder.java
+++ b/src/main/java/de/bonndan/nivio/output/map/hex/PathFinder.java
@@ -125,7 +125,7 @@ public class PathFinder {
                     if (neighbour.equals(dst)) {
                         neighbour.setParent(currentStep);
                         currentStep = neighbour;
-                        LOGGER.info("reached  {}", currentStep.hex);
+                        LOGGER.debug("reached  {}", currentStep.hex);
                         break;
                     }
 

--- a/src/main/java/de/bonndan/nivio/output/map/svg/SVGDocument.java
+++ b/src/main/java/de/bonndan/nivio/output/map/svg/SVGDocument.java
@@ -53,6 +53,7 @@ public class SVGDocument extends Component {
 
         //transform all item positions to hex map positions
         layouted.getChildren().forEach(group -> {
+            LOGGER.info("rendering group {} with items {}", group.getComponent().getIdentifier(), group.getChildren());
             group.getChildren().forEach(layoutedItem -> {
                 Hex hex = null;
                 int i = 0;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,6 +27,7 @@ server:
 nivio:
   baseUrl: ${NIVIO_BASE_URL:}
   version: #project.version#
+  pollingMilliseconds: 30000 # 30 secs
 
 ---
 spring:

--- a/src/test/java/de/bonndan/nivio/assessment/kpi/ConditionKPITest.java
+++ b/src/test/java/de/bonndan/nivio/assessment/kpi/ConditionKPITest.java
@@ -22,8 +22,7 @@ class ConditionKPITest {
 
     @Test
     public void testGreen() {
-        Item item = new Item();
-        item.setIdentifier("foo");
+        Item item = new Item(null, "foo");
         item.setLabel(Label.key(Label.condition, "bar"), "True");
 
         List<StatusValue> statusValues = kpi.getStatusValues(item);
@@ -33,8 +32,7 @@ class ConditionKPITest {
 
     @Test
     public void testRed() {
-        Item item = new Item();
-        item.setIdentifier("foo");
+        Item item = new Item(null, "foo");
         item.setLabel(Label.key(Label.condition, "bar"), "True");
         item.setLabel(Label.key(Label.condition, "baz"), "False");
 

--- a/src/test/java/de/bonndan/nivio/assessment/kpi/CustomKPITest.java
+++ b/src/test/java/de/bonndan/nivio/assessment/kpi/CustomKPITest.java
@@ -169,7 +169,7 @@ class CustomKPITest {
     }
 
     private Item getComponent(String value) {
-        Item item = new Item();
+        Item item = new Item("test", "a");
         item.setLabel(LABEL, value);
         return item;
     }

--- a/src/test/java/de/bonndan/nivio/assessment/kpi/LifecycleKPITest.java
+++ b/src/test/java/de/bonndan/nivio/assessment/kpi/LifecycleKPITest.java
@@ -24,8 +24,7 @@ class LifecycleKPITest {
 
     @Test
     public void green() {
-        Item item = new Item();
-        item.setIdentifier("foo");
+        Item item = new Item(null, "foo");
         item.setLabel(Label.lifecycle, Lifecycle.PRODUCTION.name());
 
         List<StatusValue> statusValues = kpi.getStatusValues(item);
@@ -38,8 +37,7 @@ class LifecycleKPITest {
 
     @Test
     public void orange() {
-        Item item = new Item();
-        item.setIdentifier("foo");
+        Item item = new Item(null, "foo");
         item.setLabel(Label.lifecycle, Lifecycle.END_OF_LIFE.name());
 
         List<StatusValue> statusValues = kpi.getStatusValues(item);
@@ -51,8 +49,7 @@ class LifecycleKPITest {
 
     @Test
     public void none1() {
-        Item item = new Item();
-        item.setIdentifier("foo");
+        Item item = new Item(null, "foo");
         item.setLabel(Label.lifecycle, "foo");
 
         List<StatusValue> statusValues = kpi.getStatusValues(item);
@@ -62,8 +59,7 @@ class LifecycleKPITest {
 
     @Test
     public void none2() {
-        Item item = new Item();
-        item.setIdentifier("foo");
+        Item item = new Item(null, "foo");
 
         List<StatusValue> statusValues = kpi.getStatusValues(item);
         assertNotNull(statusValues);

--- a/src/test/java/de/bonndan/nivio/assessment/kpi/ScalingKPITest.java
+++ b/src/test/java/de/bonndan/nivio/assessment/kpi/ScalingKPITest.java
@@ -16,7 +16,7 @@ class ScalingKPITest {
     public void testScale1() {
         ScalingKPI scalingKPI = new ScalingKPI();
         scalingKPI.init(null);
-        Item item = new Item();
+        Item item = new Item("test", "a");
         item.setLabel(Label.scale, "1");
 
         List<StatusValue> statusValues = scalingKPI.getStatusValues(item);
@@ -32,7 +32,7 @@ class ScalingKPITest {
     public void testScale2() {
         ScalingKPI scalingKPI = new ScalingKPI();
         scalingKPI.init(null);
-        Item item = new Item();
+        Item item = new Item("test", "a");
         item.setLabel(Label.scale, "2");
 
         List<StatusValue> statusValues = scalingKPI.getStatusValues(item);

--- a/src/test/java/de/bonndan/nivio/input/AppearanceResolverTest.java
+++ b/src/test/java/de/bonndan/nivio/input/AppearanceResolverTest.java
@@ -31,21 +31,17 @@ class AppearanceResolverTest {
         landscape.addGroup(g1);
         List<Item> items = new ArrayList<>();
 
-        Item s1 = new Item();
-        s1.setIdentifier("s1");
-        s1.setGroup("g1");
+        Item s1 = new Item("g1", "s1");
         s1.setLandscape(landscape);
         s1.setLabel(Label.type, "loadbalancer");
         items.add(s1);
-        g1.getItems().add(s1);
+        g1.addItem(s1);
 
-        Item s2 = new Item();
-        s2.setIdentifier("s2");
-        s2.setGroup("g1");
+        Item s2 = new Item("g1", "s2");
         s2.setLandscape(landscape);
         s2.setIcon("https://foo.bar/icon.png");
         items.add(s2);
-        g1.getItems().add(s2);
+        g1.addItem(s2);
 
         landscape.setItems(new HashSet<>(items));
     }

--- a/src/test/java/de/bonndan/nivio/input/DiffResolverTest.java
+++ b/src/test/java/de/bonndan/nivio/input/DiffResolverTest.java
@@ -25,15 +25,11 @@ public class DiffResolverTest {
 
         items = new ArrayList<>();
 
-        Item s1 = new Item();
-        s1.setIdentifier("s1");
-        s1.setGroup("g1");
+        Item s1 = new Item("g1","s1");
         s1.setLandscape(landscape);
         items.add(s1);
 
-        Item s2 = new Item();
-        s2.setIdentifier("s2");
-        s2.setGroup("g1");
+        Item s2 = new Item("g1","s2");
         s2.setLandscape(landscape);
         items.add(s2);
     }

--- a/src/test/java/de/bonndan/nivio/input/GroupQueryResolverTest.java
+++ b/src/test/java/de/bonndan/nivio/input/GroupQueryResolverTest.java
@@ -35,9 +35,7 @@ class GroupQueryResolverTest {
     void process_doesNotContainDuplicatedItemsInGroups() {
         LandscapeImpl landscape = LandscapeFactory.create("test");
         landscape.setProcessLog(processLog);
-        Item item = new Item();
-        item.setIdentifier("itemIdentifier");
-        item.setGroup("groupIdentifier");
+        Item item = new Item("groupIdentifier", "itemIdentifier");
         landscape.setItems(Set.of(item));
         landscape.addGroup(new Group("groupIdentifier"));
 
@@ -57,9 +55,7 @@ class GroupQueryResolverTest {
     void process_findsItemsIfQueryConditionIsNotLowercase() {
         LandscapeImpl landscape = LandscapeFactory.create("test");
         landscape.setProcessLog(processLog);
-        Item item = new Item();
-        item.setIdentifier("itemIdentifier");
-        item.setGroup("groupIdentifier");
+        Item item = new Item("groupIdentifier", "itemIdentifier");
         landscape.setItems(Set.of(item));
         landscape.addGroup(new Group("groupIdentifier"));
 
@@ -84,8 +80,7 @@ class GroupQueryResolverTest {
          */
         LandscapeImpl landscape = LandscapeFactory.create("test");
         landscape.setProcessLog(processLog);
-        Item item = new Item();
-        item.setIdentifier("itemIdentifier");
+        Item item = new Item(null, "itemIdentifier");
 
         landscape.setItems(Set.of(item));
 
@@ -104,8 +99,7 @@ class GroupQueryResolverTest {
     @Test
     void process_withLandscapeFromLandscapeFactory_containsCommonGroupIfNoGroupWasSet() {
         LandscapeImpl landscape = LandscapeFactory.create("landscapeIdentifier");
-        Item item = new Item();
-        item.setIdentifier("itemIdentifier");
+        Item item = new Item(null, "itemIdentifier");
 
         landscape.setItems(Set.of(item));
 

--- a/src/test/java/de/bonndan/nivio/input/LabelToFieldProcessorTest.java
+++ b/src/test/java/de/bonndan/nivio/input/LabelToFieldProcessorTest.java
@@ -2,6 +2,7 @@ package de.bonndan.nivio.input;
 
 import de.bonndan.nivio.input.dto.ItemDescription;
 import de.bonndan.nivio.input.dto.LandscapeDescription;
+import de.bonndan.nivio.model.Label;
 import de.bonndan.nivio.model.Link;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -46,6 +47,27 @@ class LabelToFieldProcessorTest {
         assertEquals(2, item1.getProvidedBy().size());
     }
 
+
+    @Test
+    @DisplayName("Prefixed labels are removed after processing")
+    void cleanup() {
+        ItemDescription item1 = new ItemDescription();
+        item1.getLabels().put("a", "b");
+        item1.getLabels().put("nivio.name", "foo");
+        item1.getLabels().put("nivio.description", "bar");
+        item1.getLabels().put("nivio.providedBy", "baz, bak");
+
+        LandscapeDescription input = new LandscapeDescription();
+        input.getItemDescriptions().add(item1);
+
+        assertEquals(4, item1.getLabels().size());
+
+        //when
+        processor.process(input, null);
+
+        //then
+        assertEquals(1, item1.getLabels().size()); //"a" remains
+    }
 
     @Test
     @DisplayName("Ensure comma separated strings are parsed properly")
@@ -121,5 +143,34 @@ class LabelToFieldProcessorTest {
         assertNotNull(url);
         assertNotNull(url.getHref());
         assertEquals("https://two.net", url.getHref().toString());
+    }
+
+    @Test
+    @DisplayName("Ensure comma separated links are parsed properly")
+    public void labelsToLabels() {
+        ItemDescription item1 = new ItemDescription();
+        item1.getLabels().put("a", "b");
+        item1.getLabels().put("nivio.visibility", "public");
+        item1.getLabels().put("nivio.software", "wordpress");
+        item1.getLabels().put("nivio.other", "foo");
+
+        LandscapeDescription input = new LandscapeDescription();
+        input.getItemDescriptions().add(item1);
+
+        //when
+        processor.process(input, null);
+
+        //then
+        String vis = item1.getLabel(Label.visibility);
+        assertNotNull(vis);
+        assertEquals("public", vis);
+
+        String software = item1.getLabel(Label.software);
+        assertNotNull(software);
+        assertEquals("wordpress", software);
+
+        String other = item1.getLabel("other");
+        assertNotNull(other);
+        assertEquals("foo", other);
     }
 }

--- a/src/test/java/de/bonndan/nivio/input/LandscapeDescriptionFactoryTest.java
+++ b/src/test/java/de/bonndan/nivio/input/LandscapeDescriptionFactoryTest.java
@@ -300,7 +300,7 @@ class LandscapeDescriptionFactoryTest {
         CustomKPI costKPI = new CustomKPI();
         costKPI.init(monthlyCosts);
 
-        Item item = new Item();
+        Item item = new Item("test", "a");
         item.setLabel(Label.costs, "200");
         StatusValue statusValue = costKPI.getStatusValues(item).get(0);
         assertNotNull(statusValue);

--- a/src/test/java/de/bonndan/nivio/input/MagicLabelRelationsTest.java
+++ b/src/test/java/de/bonndan/nivio/input/MagicLabelRelationsTest.java
@@ -36,8 +36,7 @@ class MagicLabelRelationsTest {
     public void findFromLabelUrlHostnameByName() {
 
         //given
-        Item elastic = new Item();
-        elastic.setIdentifier("elastic-server-as89");
+        Item elastic = new Item(null, "elastic-server-as89");
         elastic.setName("elastic");
 
         LandscapeImpl landscape = getLandscapeWith(Collections.singleton(elastic));
@@ -55,9 +54,7 @@ class MagicLabelRelationsTest {
     @DisplayName("key contains url in name and is url with hostname matching an identifier")
     public void findFromLabelUrlHostnameByIdentifier() {
         //given
-        Item elastic = new Item();
-        elastic.setIdentifier("elastic");
-
+        Item elastic = new Item(null, "elastic");
         LandscapeImpl landscape = getLandscapeWith(Collections.singleton(elastic));
 
         //when
@@ -73,9 +70,7 @@ class MagicLabelRelationsTest {
     @DisplayName("key has magic part but value is not a url")
     public void findFromLabelValueByIdentifier() {
         //given
-        Item api = new Item();
-        api.setIdentifier("api-foo");
-
+        Item api = new Item(null, "api-foo");
         LandscapeImpl landscape = getLandscapeWith(Collections.singleton(api));
 
         //when
@@ -91,8 +86,7 @@ class MagicLabelRelationsTest {
     @DisplayName("key has magic part but value is not a url")
     public void findFromLabelValueByName() {
         //given
-        Item api = new Item();
-        api.setIdentifier("api.foo.123");
+        Item api = new Item(null, "api.foo.123");
         api.setName("api-foo");
 
         LandscapeImpl landscape = getLandscapeWith(Collections.singleton(api));
@@ -110,12 +104,10 @@ class MagicLabelRelationsTest {
     @DisplayName("does nothing with more than one match")
     public void ifUncertainDoesNotLink() {
         //given
-        Item api = new Item();
-        api.setIdentifier("api.foo.123");
+        Item api = new Item(null, "api.foo.123");
         api.setName("api-foo");
 
-        Item api2 = new Item();
-        api2.setIdentifier("api.foo.234");
+        Item api2 = new Item(null, "api.foo.234");
         api2.setName("api-foo");
 
         LandscapeImpl landscape = getLandscapeWith(Set.of(api, api2));
@@ -132,14 +124,9 @@ class MagicLabelRelationsTest {
     @DisplayName("does nothing if the label value is a known identifier")
     public void ifValueIsIdentiferDoesNotLink() {
         //given
-        Item apiFoo = new Item();
-        apiFoo.setIdentifier("api-foo"); //this should match
-
-        Item foo = new Item();
-        foo.setIdentifier("foo"); //part of the label "FOO_API_URL", should not match
-
-        Item api = new Item();
-        api.setIdentifier("api"); //part of the label "FOO_API_URL", should not match
+        Item apiFoo = new Item(null, "api-foo");//this should match
+        Item foo = new Item(null, "foo"); //part of the label "FOO_API_URL", should not match
+        Item api = new Item(null, "api");//part of the label "FOO_API_URL", should not match
 
         LandscapeImpl landscape = getLandscapeWith(Set.of(apiFoo, foo, api));
 
@@ -157,8 +144,7 @@ class MagicLabelRelationsTest {
     @DisplayName("a part of the key matches an identifier")
     public void keyPartMatchesidentifier() {
         //given
-        Item hihi = new Item();
-        hihi.setIdentifier("baz");
+        Item hihi = new Item(null, "baz");
         LandscapeImpl landscape = getLandscapeWith(Collections.singleton(hihi));
 
         //when
@@ -174,8 +160,7 @@ class MagicLabelRelationsTest {
     @DisplayName("label blacklist is used")
     public void blacklistPreventsRelations() {
         //given
-        Item hihi = new Item();
-        hihi.setIdentifier("baz");
+        Item hihi = new Item(null, "baz");
         LandscapeImpl landscape = getLandscapeWith(Collections.singleton(hihi));
         landscape.getConfig().getLabelBlacklist().add(".*COMPOSITION.*");
 
@@ -190,8 +175,7 @@ class MagicLabelRelationsTest {
     @DisplayName("label blacklist is used case insensitive")
     public void blacklistPreventsRelationsCaseInsensitive() {
         //given
-        Item hihi = new Item();
-        hihi.setIdentifier("baz");
+        Item hihi = new Item(null, "baz");
         LandscapeImpl landscape = getLandscapeWith(Collections.singleton(hihi));
         landscape.getConfig().getLabelBlacklist().add(".*composition.*");
 
@@ -206,8 +190,7 @@ class MagicLabelRelationsTest {
     @DisplayName("does not link same service to itself")
     public void doesNotLinkSame() {
         //given
-        Item hihi = new Item();
-        hihi.setIdentifier(IDENTIFIER);
+        Item hihi = new Item(null, IDENTIFIER);
 
         item.getLabels().put("BASE_URL", IDENTIFIER);
         LandscapeImpl landscape = getLandscapeWith(Collections.singleton(hihi));
@@ -222,8 +205,7 @@ class MagicLabelRelationsTest {
     @Test
     public void hasProviderRelation() {
         //given
-        Item db = new Item();
-        db.setIdentifier("x.y.z");
+        Item db = new Item(null, "x.y.z");
         LandscapeImpl landscape = getLandscapeWith(Collections.singleton(db));
 
         //when

--- a/src/test/java/de/bonndan/nivio/model/GroupTest.java
+++ b/src/test/java/de/bonndan/nivio/model/GroupTest.java
@@ -1,0 +1,42 @@
+package de.bonndan.nivio.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GroupTest {
+
+    @Test
+    void doesNotAllowEmptyIdentifier() {
+        assertThrows(Exception.class, () -> new Group(""));
+    }
+
+    @Test
+    void getItemsIsImmutable() {
+        Group g = new Group("foo");
+        assertThrows(Exception.class, () -> g.getItems().add(new Item("a", "b")));
+    }
+
+    @Test
+    void addItemAllowed() {
+        Group g = new Group("foo");
+        Item item = new Item("foo", "b");
+        g.addItem(item);
+        assertEquals(1, g.getItems().size());
+    }
+
+    @Test
+    void addItemAllowedWithUnsetGroup() {
+        Group g = new Group("foo");
+        Item item = new Item(null, "b");
+        g.addItem(item);
+        assertEquals(1, g.getItems().size());
+    }
+
+    @Test
+    void addItemForbidden() {
+        Group g = new Group("foo");
+        Item item = new Item("a", "b");
+        assertThrows(IllegalArgumentException.class, () -> g.addItem(item));
+    }
+}

--- a/src/test/java/de/bonndan/nivio/model/GroupsTest.java
+++ b/src/test/java/de/bonndan/nivio/model/GroupsTest.java
@@ -14,18 +14,15 @@ public class GroupsTest {
     @Test
     public void testBy() {
         List<LandscapeItem> items = new ArrayList<>();
-        Item item1 = new Item();
-        item1.setIdentifier("1");
+        Item item1 = new Item(null,"1");
         item1.setOwner("A");
         items.add(item1);
 
-        Item item2 = new Item();
-        item2.setIdentifier("2");
+        Item item2 = new Item(null,"2");
         item2.setOwner("A");
         items.add(item2);
 
-        Item item3 = new Item();
-        item3.setIdentifier("3");
+        Item item3 = new Item(null,"3");
         item3.setOwner("B");
         items.add(item3);
 
@@ -44,17 +41,14 @@ public class GroupsTest {
     @Test
     public void testByDefault() {
         List<LandscapeItem> services = new ArrayList<>();
-        Item item1 = new Item();
-        item1.setIdentifier("1");
+        Item item1 = new Item(null,"1");
         services.add(item1);
 
-        Item item2 = new Item();
-        item2.setIdentifier("2");
+        Item item2 = new Item(null,"2");
         item2.setOwner("A");
         services.add(item2);
 
-        Item item3 = new Item();
-        item3.setIdentifier("3");
+        Item item3 = new Item(null,"3");
         item3.setOwner("B");
         services.add(item3);
 
@@ -76,20 +70,17 @@ public class GroupsTest {
     @Test
     public void testByNotUsingGroupField() {
         List<LandscapeItem> services = new ArrayList<>();
-        Item item1 = new Item();
-        item1.setIdentifier("1");
+        Item item1 = new Item(null,"1");
         item1.setOwner("A");
         item1.setGroup("content");
         services.add(item1);
 
-        Item item2 = new Item();
-        item2.setIdentifier("2");
+        Item item2 = new Item(null,"2");
         item2.setOwner("A");
         item2.setGroup("content");
         services.add(item2);
 
-        Item item3 = new Item();
-        item3.setIdentifier("3");
+        Item item3 = new Item(null,"3");
         item3.setOwner("B");
         services.add(item3);
 

--- a/src/test/java/de/bonndan/nivio/model/ItemIndexTest.java
+++ b/src/test/java/de/bonndan/nivio/model/ItemIndexTest.java
@@ -23,17 +23,13 @@ class ItemIndexTest {
 
         items = new ArrayList<>();
 
-        Item s1 = new Item();
-        s1.setIdentifier("s1");
+        Item s1 = new Item("g1", "s1");
         s1.setName("foo");
-        s1.setGroup("g1");
         s1.setLandscape(landscape);
         items.add(s1);
 
-        Item s2 = new Item();
+        Item s2 = new Item("g1", "s2");
         s2.setName("bar");
-        s2.setIdentifier("s2");
-        s2.setGroup("g1");
         s2.setLandscape(landscape);
         items.add(s2);
 
@@ -54,9 +50,7 @@ class ItemIndexTest {
         assertNotNull(landscape.getItems().pick("s1", "g1"));
         assertNotNull(landscape.getItems().pick("s2", "g1"));
 
-        Item s2 = new Item();
-        s2.setIdentifier("s2");
-        s2.setGroup("g1");
+        Item s2 = new Item("g1", "s2");
         s2.setLandscape(landscape);
 
         assertNotNull(landscape.getItems().pick(s2));
@@ -71,9 +65,7 @@ class ItemIndexTest {
     @Test
     public void pickGracefulFails() {
 
-        Item s2 = new Item();
-        s2.setIdentifier("s2");
-        s2.setGroup("g2"); //othergroup
+        Item s2 = new Item("g2", "s2");
         s2.setLandscape(landscape);
         items.add(s2);
         landscape.setItems(new HashSet<>(items));

--- a/src/test/java/de/bonndan/nivio/model/ItemTest.java
+++ b/src/test/java/de/bonndan/nivio/model/ItemTest.java
@@ -12,23 +12,16 @@ public class ItemTest {
         LandscapeImpl landscape = LandscapeFactory.create("l1");
 
 
-        Item s1 = new Item();
-        s1.setIdentifier("a");
-        s1.setGroup("g1");
+        Item s1 = new Item("g1","a");
         s1.setLandscape(landscape);
 
-        Item s2 = new Item();
-        s2.setIdentifier("a");
-        s2.setGroup("g1");
+        Item s2 = new Item("g1","a");
         s2.setLandscape(landscape);
 
-        Item s3 = new Item();
-        s3.setIdentifier("a");
-        s3.setGroup("g2");
+        Item s3 = new Item("g2","a");
         s3.setLandscape(landscape);
 
-        Item s4 = new Item();
-        s4.setIdentifier("a");
+        Item s4 = new Item(null, "a");
         s4.setLandscape(landscape);
 
         assertEquals(s1, s2);
@@ -44,20 +37,16 @@ public class ItemTest {
 
         LandscapeImpl landscape = LandscapeFactory.create("l1");
 
-        Item s1 = new Item();
-        s1.setIdentifier("a");
+        Item s1 = new Item(null, "a");
         s1.setLandscape(landscape);
 
-        Item s2 = new Item();
-        s2.setIdentifier("a");
+        Item s2 = new Item(null, "a");
         s2.setLandscape(landscape);
 
         assertEquals(s1, s2);
         assertEquals(s2, s1);
 
-        Item s3 = new Item();
-        s3.setIdentifier("a");
-        s3.setGroup("g2");
+        Item s3 = new Item("g2", "a");
         s3.setLandscape(landscape);
 
         assertNotEquals(s1, s3);
@@ -69,21 +58,15 @@ public class ItemTest {
 
         LandscapeImpl landscape = LandscapeFactory.create("l1");
 
-        Item s1 = new Item();
-        s1.setIdentifier("a");
-        s1.setGroup("g1");
+        Item s1 = new Item("g1", "a");
         s1.setLandscape(landscape);
 
-        Item s2 = new Item();
-        s2.setIdentifier("a");
-        s2.setGroup("g1");
+        Item s2 = new Item("g1", "a");
         s2.setLandscape(landscape);
 
         assertEquals(s1, s2);
 
-        Item s3 = new Item();
-        s3.setIdentifier("a");
-        s3.setGroup("g1");
+        Item s3 = new Item("g1", "a");
         s3.setLandscape(null);
 
         assertNotEquals(s1, s3);

--- a/src/test/java/de/bonndan/nivio/model/ItemTest.java
+++ b/src/test/java/de/bonndan/nivio/model/ItemTest.java
@@ -3,6 +3,7 @@ package de.bonndan.nivio.model;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ItemTest {
 
@@ -70,5 +71,18 @@ public class ItemTest {
         s3.setLandscape(null);
 
         assertNotEquals(s1, s3);
+    }
+
+    @Test
+    void setGroupIfNull() {
+        Item a = new Item(null, "a");
+        a.setGroup("b");
+        assertEquals("b", a.getGroup());
+    }
+
+    @Test
+    void setGroupForbidden() {
+        Item a = new Item("b", "a");
+        assertThrows(IllegalArgumentException.class, ()->a.setGroup("c"));
     }
 }

--- a/src/test/java/de/bonndan/nivio/model/SearchDocumentFactoryTest.java
+++ b/src/test/java/de/bonndan/nivio/model/SearchDocumentFactoryTest.java
@@ -15,8 +15,7 @@ class SearchDocumentFactoryTest {
     @Test
     public void generatesDocument() throws MalformedURLException {
         //given
-        Item item = new Item();
-        item.setIdentifier("foo");
+        Item item = new Item(null, "foo");
         item.setName("Hans");
         item.setDescription("Lorem ipsum");
         item.setContact("info@acme.com");
@@ -38,7 +37,7 @@ class SearchDocumentFactoryTest {
         assertEquals(item.getLabel("foo2"), document.get("foo2"));
 
         assertEquals(item.getLinks().get("wiki").getHref().toString(), document.get("wiki"));
-        String[] tag =  document.getValues("tag");
+        String[] tag = document.getValues("tag");
         List<String> tags = List.of(tag);
         assertTrue(tags.contains("one"));
         assertTrue(tags.contains("two"));

--- a/src/test/java/de/bonndan/nivio/model/TaggedTest.java
+++ b/src/test/java/de/bonndan/nivio/model/TaggedTest.java
@@ -10,7 +10,7 @@ class TaggedTest {
 
     @Test
     public void setsNonEmpty() {
-        Item item = new Item();
+        Item item = new Item("test", "a");
         item.setTags(new String[]{null, "", "foo", "bar"});
 
         //when
@@ -26,7 +26,7 @@ class TaggedTest {
 
     @Test
     public void setsOnlyLowerCase() {
-        Item item = new Item();
+        Item item = new Item("test", "a");
         item.setTags(new String[]{"foo", "Foo"});
 
         //when

--- a/src/test/java/de/bonndan/nivio/output/LocalServerTest.java
+++ b/src/test/java/de/bonndan/nivio/output/LocalServerTest.java
@@ -39,33 +39,33 @@ class LocalServerTest {
 
     @Test
     public void returnsServiceAsDefault() {
-        assertTrue(iconUrlContains("service", localServer.getIconUrl(new Item())));
+        assertTrue(iconUrlContains("service", localServer.getIconUrl(new Item("test", "a"))));
     }
 
     @Test
     public void returnsServiceWithUnknownType() {
-        Item item = new Item();
+        Item item = new Item("test", "a");
         item.setType("asb");
         assertTrue(iconUrlContains("service", localServer.getIconUrl(item)));
     }
 
     @Test
     public void returnsType() {
-        Item item = new Item();
+        Item item = new Item("test", "a");
         item.setType("firewall");
         assertTrue(iconUrlContains("firewall", localServer.getIconUrl(item)));
     }
 
     @Test
     public void returnsTypeIgnoreCase() {
-        Item item = new Item();
+        Item item = new Item("test", "a");
         item.setType("FireWall");
         assertTrue(iconUrlContains("firewall", localServer.getIconUrl(item)));
     }
 
     @Test
     public void returnsIcon() {
-        Item item = new Item();
+        Item item = new Item("test", "a");
         item.setIcon("http://my.icon");
         String s = localServer.getIconUrl(item).toString();
         assertEquals("http://localhost:8080/vendoricons/aHR0cDovL215Lmljb24=",s);
@@ -75,7 +75,7 @@ class LocalServerTest {
 
     @Test
     public void usesVendorIcon() {
-        Item item = new Item();
+        Item item = new Item("test", "a");
         item.setIcon(VENDOR_PREFIX + "redis");
         String s = localServer.getIconUrl(item).toString();
         assertEquals("http://localhost:8080/vendoricons/aHR0cDovL2Rvd25sb2FkLnJlZGlzLmlvL2xvZ29jb250ZXN0LzgyLnBuZw==", s);
@@ -90,7 +90,7 @@ class LocalServerTest {
         String urlprefix = String.format("http://localhost:%d", wireMockServer.port());
         localServer.setImageProxy(urlprefix);
 
-        Item item = new Item();
+        Item item = new Item("test", "a");
         item.setIcon(VENDOR_PREFIX + "redis");
         assertEquals(urlprefix + "/aHR0cDovL2Rvd25sb2FkLnJlZGlzLmlvL2xvZ29jb250ZXN0LzgyLnBuZw==", localServer.getIconUrl(item).toString());
     }
@@ -103,7 +103,7 @@ class LocalServerTest {
 
         localServer.setImageProxy(String.format("http://localhost:%d", wireMockServer.port()));
 
-        Item item = new Item();
+        Item item = new Item("test", "a");
         item.setIcon("http://my.icon");
         String urlprefix = String.format("http://localhost:%d", wireMockServer.port());
         assertEquals(urlprefix + "/aHR0cDovL215Lmljb24=", localServer.getIconUrl(item).toString());

--- a/src/test/java/de/bonndan/nivio/output/layout/AllGroupsLayoutTest.java
+++ b/src/test/java/de/bonndan/nivio/output/layout/AllGroupsLayoutTest.java
@@ -59,15 +59,11 @@ class AllGroupsLayoutTest {
 
     private SubLayout getSubLayout(Group group) {
 
-        Item bar = new Item();
-        bar.setIdentifier("bar" + group.getIdentifier());
-        bar.setGroup(group.getIdentifier());
-        group.getItems().add(bar);
+        Item bar = new Item(group.getIdentifier(), "bar" + group.getIdentifier());
+        group.addItem(bar);
 
-        Item baz = new Item();
-        baz.setIdentifier("baz" + group.getIdentifier());
-        baz.setGroup(group.getIdentifier());
-        group.getItems().add(baz);
+        Item baz = new Item(group.getIdentifier(), "baz" + group.getIdentifier());
+        group.addItem(baz);
         baz.getRelations().add(new Relation(baz, bar));
 
         return new SubLayout(group, Set.of(bar, baz), new LandscapeConfig.LayoutConfig());

--- a/src/test/java/de/bonndan/nivio/output/layout/InitialPlacementStrategyTest.java
+++ b/src/test/java/de/bonndan/nivio/output/layout/InitialPlacementStrategyTest.java
@@ -13,10 +13,10 @@ class InitialPlacementStrategyTest {
     @Test
     public void placesInCircle() {
         ArrayList<LayoutedComponent> layoutedComponents = new ArrayList<>();
-        layoutedComponents.add(new LayoutedComponent(new Item()));
-        layoutedComponents.add(new LayoutedComponent(new Item()));
-        layoutedComponents.add(new LayoutedComponent(new Item()));
-        layoutedComponents.add(new LayoutedComponent(new Item()));
+        layoutedComponents.add(new LayoutedComponent(new Item("test", "a")));
+        layoutedComponents.add(new LayoutedComponent(new Item("test", "b")));
+        layoutedComponents.add(new LayoutedComponent(new Item("test", "c")));
+        layoutedComponents.add(new LayoutedComponent(new Item("test", "d")));
 
         InitialPlacementStrategy initialPlacementStrategy = new InitialPlacementStrategy(layoutedComponents);
         Point2D.Double place1 = initialPlacementStrategy.place(0);

--- a/src/test/java/de/bonndan/nivio/output/layout/SubLayoutTest.java
+++ b/src/test/java/de/bonndan/nivio/output/layout/SubLayoutTest.java
@@ -21,15 +21,11 @@ class SubLayoutTest {
         //given
         Group foo = new Group("foo");
 
-        Item bar = new Item();
-        bar.setIdentifier("bar");
-        bar.setGroup(foo.getIdentifier());
-        foo.getItems().add(bar);
+        Item bar = new Item(foo.getIdentifier(), "bar");;
+        foo.addItem(bar);
 
-        Item baz = new Item();
-        baz.setIdentifier("baz");
-        baz.setGroup(foo.getIdentifier());
-        foo.getItems().add(baz);
+        Item baz = new Item(foo.getIdentifier(), "baz");
+        foo.addItem(baz);
         baz.getRelations().add(new Relation(baz, bar));
 
         HashSet<Item> objects = new HashSet<>();

--- a/src/test/java/de/bonndan/nivio/output/map/RenderCacheTest.java
+++ b/src/test/java/de/bonndan/nivio/output/map/RenderCacheTest.java
@@ -98,14 +98,12 @@ class RenderCacheTest {
     private LandscapeImpl getLandscape(String identifier) {
         LandscapeImpl landscape = LandscapeFactory.create(identifier);
 
-        Item item = new Item();
-        item.setIdentifier("foo");
+        Item item = new Item("bar", "foo");
         landscape.setItems(Set.of(item));
-        item.setGroup("bar");
         landscape.setItems(Collections.singleton(item));
 
         Group bar = new Group("bar");
-        bar.getItems().add(item);
+        bar.addItem(item);
         landscape.getGroups().put("bar", bar);
 
         ProcessLog test = new ProcessLog(LoggerFactory.getLogger("test"));

--- a/src/test/java/de/bonndan/nivio/output/map/svg/SVGGroupAreaFactoryTest.java
+++ b/src/test/java/de/bonndan/nivio/output/map/svg/SVGGroupAreaFactoryTest.java
@@ -48,22 +48,19 @@ class SVGGroupAreaFactoryTest {
         occupied.add(new Hex(1, 1, -2));
         occupied.add(new Hex(3, 3, -6));
 
-        Item landscapeItem = new Item();
-        landscapeItem.setIdentifier("landscapeItem");
+        Item landscapeItem = new Item("group", "landscapeItem");
 
         Map<LandscapeItem, Hex> vertexHexes = Map.of(landscapeItem, new Hex(1, 2, -3));
         Hex landscapeItemHex = new Hex(4, 5, -9);
         HexPath hexPath = new HexPath(List.of(landscapeItemHex));
 
-        Item target = new Item();
-        target.setIdentifier("target");
-        target.setGroup("group");
+        Item target = new Item("group", "target");
         RelationItem<Item> relation = new Relation(landscapeItem, target);
         SVGRelation svgRelation = new SVGRelation(hexPath, "blue", relation);
         List<SVGRelation> relations = List.of(svgRelation);
 
         Group group = new Group("group");
-        group.getItems().add(landscapeItem);
+        group.addItem(landscapeItem);
 
         SVGGroupArea svgGroupArea = SVGGroupAreaFactory.getGroup(occupied, group, vertexHexes, relations);
 
@@ -78,22 +75,19 @@ class SVGGroupAreaFactoryTest {
         occupied.add(new Hex(1, 1, -2));
         occupied.add(new Hex(3, 3, -6));
 
-        Item landscapeItem = new Item();
-        landscapeItem.setIdentifier("landscapeItem");
+        Item landscapeItem = new Item("group", "landscapeItem");
 
         Map<LandscapeItem, Hex> vertexHexes = Map.of(landscapeItem, new Hex(1, 2, -3));
         Hex landscapeItemHex = new Hex(4, 5, -9);
         HexPath hexPath = new HexPath(List.of(landscapeItemHex));
 
-        Item target = new Item();
-        target.setIdentifier("target");
-        target.setGroup("otherGroup");
+        Item target = new Item("otherGroup", "target");
         RelationItem<Item> relation = new Relation(landscapeItem, target);
         SVGRelation svgRelation = new SVGRelation(hexPath, "blue", relation);
         List<SVGRelation> relations = List.of(svgRelation);
 
         Group group = new Group("group");
-        group.getItems().add(landscapeItem);
+        group.addItem(landscapeItem);
 
         SVGGroupArea svgGroupArea = SVGGroupAreaFactory.getGroup(occupied, group, vertexHexes, relations);
 
@@ -107,21 +101,19 @@ class SVGGroupAreaFactoryTest {
         occupied.add(new Hex(1, 1, -2));
         occupied.add(new Hex(3, 3, -6));
 
-        Item landscapeItem = new Item();
-        landscapeItem.setIdentifier("landscapeItem");
+        Item landscapeItem = new Item("group", "landscapeItem");
 
         Map<LandscapeItem, Hex> vertexHexes = Map.of(landscapeItem, new Hex(1, 2, -3));
         Hex landscapeItemHex = new Hex(4, 5, -9);
         HexPath hexPath = new HexPath(List.of(landscapeItemHex));
 
-        Item target = new Item();
-        target.setIdentifier("target");
+        Item target = new Item(null, "target");
         RelationItem<Item> relation = new Relation(landscapeItem, target);
         SVGRelation svgRelation = new SVGRelation(hexPath, "blue", relation);
         List<SVGRelation> relations = List.of(svgRelation);
 
         Group group = new Group("group");
-        group.getItems().add(landscapeItem);
+        group.addItem(landscapeItem);
 
         SVGGroupArea svgGroupArea = SVGGroupAreaFactory.getGroup(occupied, group, vertexHexes, relations);
 
@@ -135,22 +127,19 @@ class SVGGroupAreaFactoryTest {
         occupied.add(new Hex(1, 1, -2));
         occupied.add(new Hex(3, 3, -6));
 
-        Item landscapeItem = new Item();
-        landscapeItem.setIdentifier("landscapeItem");
+        Item landscapeItem = new Item("group", "landscapeItem");
 
         Map<LandscapeItem, Hex> vertexHexes = Map.of(landscapeItem, new Hex(1, 2, -3));
         HexPath hexPath = new HexPath(List.of(new Hex(4, 5, -9)));
 
-        Item source = new Item();
-        source.setIdentifier("source");
-        Item target = new Item();
-        target.setIdentifier("target");
+        Item source = new Item(null,"source");
+        Item target = new Item(null, "target");
         RelationItem<Item> relation = new Relation(source, target);
         SVGRelation svgRelation = new SVGRelation(hexPath, "blue", relation);
         List<SVGRelation> relations = List.of(svgRelation);
 
         Group group = new Group("group");
-        group.getItems().add(landscapeItem);
+        group.addItem(landscapeItem);
 
         SVGGroupArea svgGroupArea = SVGGroupAreaFactory.getGroup(occupied, group, vertexHexes, relations);
 

--- a/src/test/java/de/bonndan/nivio/output/map/svg/SVGGroupAreaOutlineFactoryTest.java
+++ b/src/test/java/de/bonndan/nivio/output/map/svg/SVGGroupAreaOutlineFactoryTest.java
@@ -20,15 +20,13 @@ class SVGGroupAreaOutlineFactoryTest {
         Hex e2 = new Hex(0, 20, -20);
         Set<Hex> occupied = Set.of(e1, e2);
 
-        Item item1 = new Item();
-        item1.setIdentifier("bar");
-        Item item2 = new Item();
-        item2.setIdentifier("baz");
+        Item item1 = new Item("foo", "bar");
+        Item item2 = new Item("foo", "baz");
 
         Group foo = new Group("foo");
         foo.setColor("005500");
-        foo.getItems().add(item1);
-        foo.getItems().add(item2);
+        foo.addItem(item1);
+        foo.addItem(item2);
 
         Map<LandscapeItem, Hex> map = new HashMap<>();
         map.put(item1, e1);

--- a/src/test/java/de/bonndan/nivio/output/map/svg/SVGGroupAreaTest.java
+++ b/src/test/java/de/bonndan/nivio/output/map/svg/SVGGroupAreaTest.java
@@ -16,20 +16,13 @@ class SVGGroupAreaTest {
         occupied.add(new Hex(1, 1, -2));
         occupied.add(new Hex(3, 3, -6));
 
-        Item landscapeItem = new Item();
-        landscapeItem.setIdentifier("landscapeItem");
-
+        Item landscapeItem = new Item("group", "landscapeItem");
         Map<LandscapeItem, Hex> vertexHexes = Map.of(landscapeItem, new Hex(1, 2, -3));
 
-        Item source = new Item();
-        source.setIdentifier("source");
-        Item target = new Item();
-        target.setIdentifier("target");
-
         Group group = new Group("group");
-        group.getItems().add(landscapeItem);
+        group.addItem(landscapeItem);
 
-        SVGGroupArea svgGroupArea = SVGGroupAreaFactory.getGroup(occupied, group, vertexHexes, new ArrayList<SVGRelation>());
+        SVGGroupArea svgGroupArea = SVGGroupAreaFactory.getGroup(occupied, group, vertexHexes, new ArrayList<>());
 
         assertTrue(svgGroupArea.render().render().contains("<text x=\"350.0\" y=\"916.217782649107\" font-size=\"24\" text-anchor=\"middle\" class=\"groupLabel\">group</text>"));
     }

--- a/src/test/java/de/bonndan/nivio/output/map/svg/SVGItemLabelTest.java
+++ b/src/test/java/de/bonndan/nivio/output/map/svg/SVGItemLabelTest.java
@@ -17,8 +17,7 @@ class SVGItemLabelTest {
         LandscapeImpl landscape = LandscapeFactory.create("l1");
 
         // item has no group
-        Item foo = new Item();
-        foo.setIdentifier("foo");
+        Item foo = new Item(null, "foo");
         foo.setLandscape(landscape);
 
 

--- a/src/test/java/de/bonndan/nivio/output/map/svg/SVGItemTest.java
+++ b/src/test/java/de/bonndan/nivio/output/map/svg/SVGItemTest.java
@@ -20,8 +20,7 @@ class SVGItemTest {
         LandscapeImpl landscape = LandscapeFactory.create("l1");
 
         // item has no group
-        Item foo = new Item();
-        foo.setIdentifier("foo");
+        Item foo = new Item(null, "foo");
         foo.setLandscape(landscape);
 
         SVGItem svgItem = new SVGItem(null, new LayoutedComponent(foo), new Point2D.Double(1,1));
@@ -34,8 +33,7 @@ class SVGItemTest {
         LandscapeImpl landscape = LandscapeFactory.create("l1");
 
         // item has no group
-        Item foo = new Item();
-        foo.setIdentifier("foo");
+        Item foo = new Item(null, "foo");
         foo.setLandscape(landscape);
 
         SVGItem svgItem = new SVGItem(null, new LayoutedComponent(foo), new Point2D.Double(1,2.0303030));

--- a/src/test/java/de/bonndan/nivio/output/map/svg/SVGRelationTest.java
+++ b/src/test/java/de/bonndan/nivio/output/map/svg/SVGRelationTest.java
@@ -18,12 +18,10 @@ class SVGRelationTest {
         LandscapeImpl landscape = LandscapeFactory.create("l1");
 
         //both items have no group
-        Item foo = new Item();
-        foo.setIdentifier("foo");
+        Item foo = new Item(null, "foo");
         foo.setLandscape(landscape);
 
-        Item bar = new Item();
-        bar.setIdentifier("bar");
+        Item bar = new Item(null, "bar");
         bar.setLandscape(landscape);
 
         RelationItem<Item> itemRelationItem = new Relation(foo, bar);

--- a/src/test/java/de/bonndan/nivio/output/map/svg/SVGRendererTest.java
+++ b/src/test/java/de/bonndan/nivio/output/map/svg/SVGRendererTest.java
@@ -60,8 +60,7 @@ class SVGRendererTest {
 
         lc.getChildren().add(glc);
 
-        Item baz = new Item();
-        baz.setIdentifier("baz");
+        Item baz = new Item(null,"baz");
 
         LayoutedComponent ilc = new LayoutedComponent(baz);
         glc.setWidth(50);


### PR DESCRIPTION
closes #260 

The problem is that Item.hashCode is dependent on the "group" field value, which had been changed after items were added to a Set. Usually Sets only contain unique items, but the item group was changed after having been added to the collection, so the equality to duplicates was not given anymore.

In addition, Group.getItems now returns an immutable copy and an addItem method has been added which enforces correct item group field values.

This is a step towards #212 , but does not eliminate all mutability.