### PR TITLE
Docker: use a smaller base image. Closes #282

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # use not slim base image, because libfontmanager needs libfreetype (mfbieber)
-FROM openjdk:11-jre
+FROM adoptopenjdk/openjdk11:x86_64-alpine-jre-11.0.8_10
 
 ENV JAVA_TOOL_OPTIONS="-Xmx400m"
 VOLUME /tmp


### PR DESCRIPTION
Replaces the base image `openjdk:11-jre` by `adoptopenjdk/openjdk11:x86_64-alpine-jre-11.0.8_10`.
Closes issue #282 

Size comparison:
- Previous image -> nvidio:openjdk-11-jre (from commit [ee8903c](https://github.com/dedica-team/nivio/commit/ee8903c1931ce082e798c4c2467f873a67ddb21b))
- Current image -> nvidio:adoptopenjdk-11-alpine

![nivio-docker-images](https://user-images.githubusercontent.com/461393/94295211-2f60b900-ff61-11ea-9658-4957caad2e90.png)
