### PR TITLE
JUnit cleanup

### DIFF
--- a/src/test/java/de/bonndan/nivio/input/IndexerIntegrationTest.java
+++ b/src/test/java/de/bonndan/nivio/input/IndexerIntegrationTest.java
@@ -4,7 +4,6 @@ import de.bonndan.nivio.input.dto.LandscapeDescription;
 import de.bonndan.nivio.input.dto.ItemDescription;
 import de.bonndan.nivio.model.*;
 import de.bonndan.nivio.output.LocalServer;
-import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -229,7 +228,7 @@ public class IndexerIntegrationTest {
         LandscapeImpl landscape = index("/src/test/resources/example/example_templates.yml");
 
         LandscapeItem web = landscape.getItems().pick("web", null);
-        Assert.assertNotNull(web);
+        assertNotNull(web);
         assertEquals("web", web.getIdentifier());
         assertEquals("webservice", web.getType());
     }

--- a/src/test/java/de/bonndan/nivio/input/IndexerIntegrationTest.java
+++ b/src/test/java/de/bonndan/nivio/input/IndexerIntegrationTest.java
@@ -5,11 +5,9 @@ import de.bonndan.nivio.input.dto.ItemDescription;
 import de.bonndan.nivio.model.*;
 import de.bonndan.nivio.output.LocalServer;
 import org.junit.Assert;
-import org.junit.FixMethodOrder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.runners.MethodSorters;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,7 +28,6 @@ import static org.junit.jupiter.api.Assertions.*;
 @SpringBootTest
 @ExtendWith(MockitoExtension.class)
 @ActiveProfiles("test")
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class IndexerIntegrationTest {
 
     @Autowired

--- a/src/test/java/de/bonndan/nivio/input/KubernetesTest.java
+++ b/src/test/java/de/bonndan/nivio/input/KubernetesTest.java
@@ -7,9 +7,8 @@ import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.PodSpecBuilder;
 import io.fabric8.kubernetes.api.model.PodStatusBuilder;
-import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
-import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
-import org.junit.jupiter.api.AfterEach;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -21,19 +20,13 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+@EnableKubernetesMockClient(crud = true)
 public class KubernetesTest {
 
-    private NamespacedKubernetesClient client;
-    private KubernetesServer server;
+    static KubernetesClient client;
 
     @BeforeEach
     void setup() {
-
-        server = new KubernetesServer(false, true);
-        server.before();
-
-        client = server.getClient();
-
         List<Container> containers = new ArrayList<>();
         Container c1 = new Container();
         c1.setImage("postgres:9.5");
@@ -79,14 +72,5 @@ public class KubernetesTest {
         assertEquals("pod1", itemDescription.getName());
         assertEquals("pod1", itemDescription.getIdentifier());
         assertEquals("testgroup", itemDescription.getLabels().get("release"));
-
-        tearDown();
     }
-
-    @AfterEach
-    private void tearDown() {
-        server.after();
-    }
-
-
 }

--- a/src/test/java/de/bonndan/nivio/input/KubernetesTest.java
+++ b/src/test/java/de/bonndan/nivio/input/KubernetesTest.java
@@ -18,8 +18,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class KubernetesTest {
 

--- a/src/test/java/de/bonndan/nivio/input/LandscapeDescriptionFactoryTest.java
+++ b/src/test/java/de/bonndan/nivio/input/LandscapeDescriptionFactoryTest.java
@@ -24,8 +24,7 @@ import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.*;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
 

--- a/src/test/java/de/bonndan/nivio/input/RelationEndpointResolverTest.java
+++ b/src/test/java/de/bonndan/nivio/input/RelationEndpointResolverTest.java
@@ -18,9 +18,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 
 class RelationEndpointResolverTest {

--- a/src/test/java/de/bonndan/nivio/input/SourceReferencesResolverTest.java
+++ b/src/test/java/de/bonndan/nivio/input/SourceReferencesResolverTest.java
@@ -16,9 +16,9 @@ import org.springframework.util.StringUtils;
 import java.io.File;
 import java.util.*;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 

--- a/src/test/java/de/bonndan/nivio/input/TemplateResolverTest.java
+++ b/src/test/java/de/bonndan/nivio/input/TemplateResolverTest.java
@@ -16,8 +16,8 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.util.*;
 
-import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 

--- a/src/test/java/de/bonndan/nivio/input/dto/InputFormatHandlerNivioTest.java
+++ b/src/test/java/de/bonndan/nivio/input/dto/InputFormatHandlerNivioTest.java
@@ -9,7 +9,6 @@ import de.bonndan.nivio.input.nivio.InputFormatHandlerNivio;
 import de.bonndan.nivio.model.*;
 import de.bonndan.nivio.observation.FileSourceReferenceObserver;
 import de.bonndan.nivio.observation.InputFormatObserver;
-import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -18,9 +17,9 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 class InputFormatHandlerNivioTest {
@@ -72,7 +71,7 @@ class InputFormatHandlerNivioTest {
         assertEquals(3, service.getInterfaces().size());
         service.getInterfaces().forEach(dataFlow -> {
             if (dataFlow.getDescription().equals("posts")) {
-                Assert.assertEquals("form", dataFlow.getFormat());
+                assertEquals("form", dataFlow.getFormat());
             }
         });
 
@@ -84,7 +83,7 @@ class InputFormatHandlerNivioTest {
         assertEquals(2, dataflows.size());
         dataflows.forEach(dataFlow -> {
             if (dataFlow.getDescription().equals("kpis")) {
-                Assert.assertEquals("content-kpi-dashboard", dataFlow.getTarget());
+                assertEquals("content-kpi-dashboard", dataFlow.getTarget());
             }
         });
 

--- a/src/test/java/de/bonndan/nivio/model/FullyQualifiedIdentifierTest.java
+++ b/src/test/java/de/bonndan/nivio/model/FullyQualifiedIdentifierTest.java
@@ -3,7 +3,6 @@ package de.bonndan.nivio.model;
 import de.bonndan.nivio.input.dto.ItemDescription;
 import org.junit.jupiter.api.Test;
 
-import static junit.framework.TestCase.assertFalse;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class FullyQualifiedIdentifierTest {

--- a/src/test/java/de/bonndan/nivio/model/GroupsTest.java
+++ b/src/test/java/de/bonndan/nivio/model/GroupsTest.java
@@ -6,8 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class GroupsTest {
 

--- a/src/test/java/de/bonndan/nivio/model/ItemFactoryTest.java
+++ b/src/test/java/de/bonndan/nivio/model/ItemFactoryTest.java
@@ -7,8 +7,8 @@ import org.junit.jupiter.api.Test;
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class ItemFactoryTest {
 

--- a/src/test/java/de/bonndan/nivio/model/ItemIndexTest.java
+++ b/src/test/java/de/bonndan/nivio/model/ItemIndexTest.java
@@ -7,8 +7,8 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ItemIndexTest {

--- a/src/test/java/de/bonndan/nivio/model/ItemMatcherTest.java
+++ b/src/test/java/de/bonndan/nivio/model/ItemMatcherTest.java
@@ -3,7 +3,6 @@ package de.bonndan.nivio.model;
 import de.bonndan.nivio.input.dto.ItemDescription;
 import org.junit.jupiter.api.Test;
 
-import static junit.framework.TestCase.assertFalse;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class ItemMatcherTest {

--- a/src/test/java/de/bonndan/nivio/model/ItemTest.java
+++ b/src/test/java/de/bonndan/nivio/model/ItemTest.java
@@ -2,8 +2,7 @@ package de.bonndan.nivio.model;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ItemTest {
 

--- a/src/test/java/de/bonndan/nivio/notification/MessagingServiceTest.java
+++ b/src/test/java/de/bonndan/nivio/notification/MessagingServiceTest.java
@@ -5,7 +5,6 @@ import de.bonndan.nivio.ProcessingFinishedEvent;
 import de.bonndan.nivio.input.dto.LandscapeDescription;
 import de.bonndan.nivio.model.LandscapeFactory;
 import de.bonndan.nivio.model.LandscapeImpl;
-import org.junit.Before;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.messaging.simp.SimpMessagingTemplate;


### PR DESCRIPTION
The project uses JUnit Jupiter 5.4.0, but still has the old JUnit 4.12 in its classpath via transitive dependencies. This leads to the fact that code from JUnit 4.12 can be (and is!) used even though it's not supposed to be, and may break if the transitive dependencies upgrade their own dependencies.

This PR cleans up these usages so the test suite uses strictly JUnit Jupiter classes.

It includes the following changes (see individual commits for additional details)
- Removes unused JUnit 4 imports
- Uses assertions from `org.junit.jupiter.api.Assertions` instead of `org.junit.Assert` or `junit.framework.TestCase`
- `IndexerIntegrationTest` used JUnit 4's `FixMethodOrder` annotation to fix the order in which the tests are executed, which did not work, as this annotation is not honored by the JUnit Jupiter runner. Since the test passes and the method order isn't important any more, this annotation was removed.
- `KubernetesTest` explicitly initialized a `KubernetesServer` instance, in JUnit 4 style. The test was rewritten to use the modern `EnableKubernetesMockClient` test extension, and in the process remove some boiler-plate code associated with the `KubernetesServer`.