### PR TITLE
Fixing pointer mouse cursor for triangles in relations

### DIFF
--- a/src/main/java/de/bonndan/nivio/output/map/svg/SVGRelation.java
+++ b/src/main/java/de/bonndan/nivio/output/map/svg/SVGRelation.java
@@ -51,7 +51,7 @@ class SVGRelation extends Component {
                     .attr("d", stringPath)
                     .attr("stroke", fillId);
             if (isPlanned) {
-                path.attr("stroke-dasharray", 10);
+                path.attr("stroke-dasharray", 30);
                 path.attr("opacity", 0.7);
             }
             return addAttributes(g(path, label(bezierPath, fillId)), relation);
@@ -110,7 +110,7 @@ class SVGRelation extends Component {
         return SvgTagCreator.text(text)
                 .attr("x", xOffset)
                 .attr("y", 0)
-                .attr("font-size", "3em")
+                .attr("font-size", "4em")
                 .condAttr(!StringUtils.isEmpty(fillId), "fill", fillId)
                 .attr("transform", transform);
     }

--- a/src/main/resources/static/css/svg.css
+++ b/src/main/resources/static/css/svg.css
@@ -45,13 +45,16 @@
   fill: none;
   stroke-width: 0.2em;
   stroke-opacity: 0.8;
-  stroke-linecap: round;
+  stroke-linecap: butt;
   stroke-linejoin: round;
 }
 
-.map g.relation path {
-  stroke-width: 0.8em;
+.map g.relation {
   cursor: pointer;
+}
+
+.map g.relation path {
+  stroke-width: 1em;
 }
 
 .map g.groupArea {


### PR DESCRIPTION
- made dashes "butt" instead of "round"
- made lines and triangles thicker 
- added cursor pointer to triangles by setting the attribute to the .map g.relation (the triangles do not contain a path tag)

I think now it looks a little bit better:
<img width="1210" alt="nivio5" src="https://user-images.githubusercontent.com/37021266/104372993-91e5c100-5520-11eb-9c0a-0a85d1ec99e5.png">
