### PR TITLE
Temporarily removing locateFunction dep in deps array (results in a warning)

### DIFF
--- a/src/main/app/src/Components/Landscape/Search/Search.tsx
+++ b/src/main/app/src/Components/Landscape/Search/Search.tsx
@@ -85,7 +85,7 @@ const Search: React.FC<PropsInterface> = ({ locateFunction, setSidebarContent, .
       />
     ));
     setSidebarContent(searchResult);
-  }, [results, setSidebarContent, locateFunction]);
+  }, [results, setSidebarContent]);
 
   async function loadFacets(identifier: string | undefined) {
     if (identifier == null) {

--- a/src/main/app/src/Components/Landscape/Search/Search.tsx
+++ b/src/main/app/src/Components/Landscape/Search/Search.tsx
@@ -85,7 +85,7 @@ const Search: React.FC<PropsInterface> = ({ locateFunction, setSidebarContent, .
       />
     ));
     setSidebarContent(searchResult);
-  }, [results, setSidebarContent]);
+  }, [results, setSidebarContent]);// eslint-disable-line react-hooks/exhaustive-deps
 
   async function loadFacets(identifier: string | undefined) {
     if (identifier == null) {


### PR DESCRIPTION
By (temporarily!) removing the locateFunction dep in the deps array of the useEffect hook that triggers the search results to be displayed in the sidebar, we can fix the unwanted effect that no items can be clicked. This happened because the change of locateFunction (which many components have as state and is triggered in Map.tsx) triggers this useEffect hook, which in turn triggers a re-render, etc.

We should consider not having these kinds of functions in many components but rather use the React useContext and ContextProvider mechanism instead.