### PR TITLE
[#574] replaced deprecated Lucene RamDirectory

### DIFF
--- a/src/main/java/de/bonndan/nivio/model/Landscape.java
+++ b/src/main/java/de/bonndan/nivio/model/Landscape.java
@@ -90,7 +90,7 @@ public class Landscape implements Linked, Component, Labeled, Assessable {
     ) {
         this.identifier = validateIdentifier(Objects.requireNonNull(identifier));
         this.groups = groups;
-        this.searchIndex = new SearchIndex();
+        this.searchIndex = new SearchIndex(identifier);
         this.items = new ItemIndex<>(Item.class);
         this.name = Objects.requireNonNull(name);
         this.contact = contact;

--- a/src/main/java/de/bonndan/nivio/search/SearchIndex.java
+++ b/src/main/java/de/bonndan/nivio/search/SearchIndex.java
@@ -61,13 +61,13 @@ public class SearchIndex {
 
         //init lucene
         try {
-            String tmpdir = System.getProperty("java.io.tmpdir");
-            String fsSafeIdentifier = StringUtils.trimTrailingCharacter(identifier.replaceAll("[^0-9a-fA-F]", "_"), File.separatorChar);
+            var tmpdir = System.getProperty("java.io.tmpdir");
+            var fsSafeIdentifier = StringUtils.trimTrailingCharacter(identifier.replaceAll("[^0-9a-fA-F]", "_"), File.separatorChar);
             searchIndex = new MMapDirectory(Path.of(tmpdir, "nivio-document-index", fsSafeIdentifier));
             taxoIndex = new MMapDirectory(Path.of(tmpdir, "nivio-facet-index", fsSafeIdentifier));
         } catch (IOException e) {
-            LOGGER.error("Failed to create search index: " + e.getMessage());
-            throw new RuntimeException("Failed to create search index.", e);
+            LOGGER.error(String.format("Failed to create search index: %s", e.getMessage()));
+            throw new SearchIndexCreationException("Failed to create search index.", e);
         }
     }
 

--- a/src/main/java/de/bonndan/nivio/search/SearchIndex.java
+++ b/src/main/java/de/bonndan/nivio/search/SearchIndex.java
@@ -2,7 +2,6 @@ package de.bonndan.nivio.search;
 
 import de.bonndan.nivio.assessment.Assessment;
 import de.bonndan.nivio.assessment.StatusValue;
-import de.bonndan.nivio.model.Component;
 import de.bonndan.nivio.model.FullyQualifiedIdentifier;
 import de.bonndan.nivio.model.Item;
 import de.bonndan.nivio.model.Landscape;
@@ -16,20 +15,27 @@ import org.apache.lucene.facet.taxonomy.FastTaxonomyFacetCounts;
 import org.apache.lucene.facet.taxonomy.TaxonomyWriter;
 import org.apache.lucene.facet.taxonomy.directory.DirectoryTaxonomyReader;
 import org.apache.lucene.facet.taxonomy.directory.DirectoryTaxonomyWriter;
-import org.apache.lucene.index.*;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.queryparser.classic.MultiFieldQueryParser;
 import org.apache.lucene.queryparser.classic.ParseException;
 import org.apache.lucene.queryparser.classic.QueryParser;
-import org.apache.lucene.search.*;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.store.Directory;
-import org.apache.lucene.store.RAMDirectory;
+import org.apache.lucene.store.MMapDirectory;
 import org.apache.lucene.util.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.lang.NonNull;
 import org.springframework.util.StringUtils;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -51,26 +57,33 @@ public class SearchIndex {
     /**
      * Creates a new empty index.
      */
-    public SearchIndex() {
+    public SearchIndex(@NonNull final String identifier) {
 
         //init lucene
-        searchIndex = new RAMDirectory();
-        taxoIndex = new RAMDirectory();
+        try {
+            String tmpdir = System.getProperty("java.io.tmpdir");
+            String fsSafeIdentifier = StringUtils.trimTrailingCharacter(identifier.replaceAll("[^0-9a-fA-F]", "_"), File.separatorChar);
+            searchIndex = new MMapDirectory(Path.of(tmpdir, "nivio-document-index", fsSafeIdentifier));
+            taxoIndex = new MMapDirectory(Path.of(tmpdir, "nivio-facet-index", fsSafeIdentifier));
+        } catch (IOException e) {
+            LOGGER.error("Failed to create search index: " + e.getMessage());
+            throw new RuntimeException("Failed to create search index.", e);
+        }
     }
 
     /**
+     * Index a landscape.
      *
-     * @param landscape
-     * @param assessment
+     * @param landscape  the landscape to index
+     * @param assessment the current assessment (status are indexed, too)
      */
-    public void indexForSearch(Landscape landscape, Assessment assessment) {
-        Set<Item> items = landscape.getItems().all();
-        indexItems(items, assessment.getResults());
+    public void indexForSearch(@NonNull final Landscape landscape, @NonNull final Assessment assessment) {
+        Set<Item> items = Objects.requireNonNull(landscape).getItems().all();
+        indexItems(items, Objects.requireNonNull(assessment).getResults());
     }
 
     /**
      * Creates a search index based in a snapshot of current items state (later modifications won't be shown).
-     *
      */
     private void indexItems(Set<Item> items, Map<FullyQualifiedIdentifier, List<StatusValue>> results) {
         try {

--- a/src/main/java/de/bonndan/nivio/search/SearchIndexCreationException.java
+++ b/src/main/java/de/bonndan/nivio/search/SearchIndexCreationException.java
@@ -1,0 +1,7 @@
+package de.bonndan.nivio.search;
+
+public class SearchIndexCreationException extends RuntimeException {
+    public SearchIndexCreationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/test/java/de/bonndan/nivio/search/SearchIndexCreationExceptionTest.java
+++ b/src/test/java/de/bonndan/nivio/search/SearchIndexCreationExceptionTest.java
@@ -1,0 +1,18 @@
+package de.bonndan.nivio.search;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SearchIndexCreationExceptionTest {
+
+    @Test
+    void testException() {
+        var searchIndexCreationException = new SearchIndexCreationException("test", new IOException("test"));
+        assertThat(searchIndexCreationException.getClass()).isEqualTo(SearchIndexCreationException.class);
+        assertThat(searchIndexCreationException.getMessage()).isEqualTo("test");
+        assertThat(searchIndexCreationException.getCause()).isEqualToComparingFieldByField(new IOException("test"));
+    }
+}

--- a/src/test/java/de/bonndan/nivio/search/SearchIndexCreationExceptionTest.java
+++ b/src/test/java/de/bonndan/nivio/search/SearchIndexCreationExceptionTest.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class SearchIndexCreationExceptionTest {
+class SearchIndexCreationExceptionTest {
 
     @Test
     void testException() {

--- a/src/test/java/de/bonndan/nivio/search/SearchIndexTest.java
+++ b/src/test/java/de/bonndan/nivio/search/SearchIndexTest.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class SearchIndexTest {
 
@@ -17,7 +18,7 @@ class SearchIndexTest {
 
     @BeforeEach
     void setup() {
-        searchIndex = new SearchIndex();
+        searchIndex = new SearchIndex("test");
 
         Set<Item> components = new HashSet<>();
         components.add(ItemFactory.getTestItemBuilder("foo", "a")
@@ -33,6 +34,19 @@ class SearchIndexTest {
 
         Landscape landscape = LandscapeFactory.createForTesting("test", "test").withItems(components).build();
         searchIndex.indexForSearch(landscape, new Assessment(Map.of()));
+    }
+
+    @Test
+    void checksNull() {
+
+        //given
+        Landscape landscape = LandscapeFactory.createForTesting("test", "test").build();
+        Assessment assessment = new Assessment(Map.of());
+
+        //when
+        assertThatThrownBy(() -> searchIndex.indexForSearch(null, assessment)).isInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> searchIndex.indexForSearch(landscape, null)).isInstanceOf(NullPointerException.class);
     }
 
     @Test

--- a/src/test/java/de/bonndan/nivio/search/SearchIndexTest.java
+++ b/src/test/java/de/bonndan/nivio/search/SearchIndexTest.java
@@ -5,6 +5,7 @@ import de.bonndan.nivio.model.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -71,6 +72,10 @@ class SearchIndexTest {
         //when
         Set<FullyQualifiedIdentifier> andQuery = searchIndex.search("Arnold AND Sylvester");
         assertThat(andQuery).hasSize(0);
+
+        //when
+        Set<FullyQualifiedIdentifier> facetDelimiter = searchIndex.search("Sylvester:");
+        assertThat(andQuery).hasSize(0);
     }
 
     @Test
@@ -95,5 +100,18 @@ class SearchIndexTest {
         //when
         Set<FullyQualifiedIdentifier> strong = searchIndex.search("aRn");
         assertThat(strong).hasSize(1);
+    }
+
+    @Test
+    void searchIndexIOException() {
+        var searchIndex = new SearchIndex("null");
+    }
+
+
+    @Test
+    void testFacets() {
+        var facets = searchIndex.facets();
+        assertThat(facets.getClass()).isEqualTo(ArrayList.class);
+        assertThat(facets.size()).isEqualTo(2);
     }
 }

--- a/src/test/java/de/bonndan/nivio/search/SearchIndexTest.java
+++ b/src/test/java/de/bonndan/nivio/search/SearchIndexTest.java
@@ -75,7 +75,7 @@ class SearchIndexTest {
 
         //when
         Set<FullyQualifiedIdentifier> facetDelimiter = searchIndex.search("Sylvester:");
-        assertThat(andQuery).hasSize(0);
+        assertThat(facetDelimiter).isEmpty();
     }
 
     @Test
@@ -100,11 +100,6 @@ class SearchIndexTest {
         //when
         Set<FullyQualifiedIdentifier> strong = searchIndex.search("aRn");
         assertThat(strong).hasSize(1);
-    }
-
-    @Test
-    void searchIndexIOException() {
-        var searchIndex = new SearchIndex("null");
     }
 
 


### PR DESCRIPTION
hopefully closes #574 

If the error persists we need to make SearchIndex instances persisting (e.g. using a repo). The fix is to make search index location predictable using the landscape identifier. Beforehands a new (random?) location was used with every new instance.