### PR TITLE
[#585] fix for asessment creation

### DIFF
--- a/src/main/java/de/bonndan/nivio/search/SearchIndexingEventListener.java
+++ b/src/main/java/de/bonndan/nivio/search/SearchIndexingEventListener.java
@@ -24,13 +24,7 @@ public class SearchIndexingEventListener {
         final Landscape landscape = event.getLandscape();
         final SearchIndex searchIndex = landscape.getSearchIndex();
 
-        //see https://github.com/dedica-team/nivio/issues/519
-        var assessment = assessmentRepository.getAssessment(landscape.getFullyQualifiedIdentifier());
-        if (assessment.isEmpty()) {
-            searchIndex.indexForSearch(landscape, assessmentRepository.createAssessment(landscape));
-        } else {
-            searchIndex.indexForSearch(landscape, assessment.get());
-        }
-
+        //we create a new assessment here, since the landscape has changed
+        searchIndex.indexForSearch(landscape, assessmentRepository.createAssessment(landscape));
     }
 }

--- a/src/test/java/de/bonndan/nivio/search/SearchIndexingEventListenerTest.java
+++ b/src/test/java/de/bonndan/nivio/search/SearchIndexingEventListenerTest.java
@@ -34,7 +34,7 @@ class SearchIndexingEventListenerTest {
     void onProcessingFinishedEvent() {
         //given
         var assessment = AssessmentFactory.createAssessment(landscape);
-        when(assessmentRepository.getAssessment(Mockito.any())).thenReturn(Optional.of(assessment));
+        when(assessmentRepository.createAssessment(eq(landscape))).thenReturn(assessment);
         ProcessingFinishedEvent e = new ProcessingFinishedEvent(new LandscapeDescription("foo"), landscape, new ProcessingChangelog());
         SearchIndex searchIndex = mock(SearchIndex.class);
         when(landscape.getSearchIndex()).thenReturn(searchIndex);
@@ -49,6 +49,7 @@ class SearchIndexingEventListenerTest {
         verify(landscape).getSearchIndex();
         verify(landscape).getKpis();
         verify(landscape).applyKPIs(any());
+        verify(assessmentRepository).createAssessment(eq(landscape));
         verify(searchIndex).indexForSearch(eq(landscape), any(Assessment.class));
     }
 


### PR DESCRIPTION
Old assessment was loaded on landscape change event. I missed that in the review.