### PR TITLE
Bugfix: Hot reloading of landscape data

### DIFF
--- a/src/main/app/src/Components/Landscape/Dashboard/StatusBar.tsx
+++ b/src/main/app/src/Components/Landscape/Dashboard/StatusBar.tsx
@@ -53,7 +53,7 @@ const StatusBar: React.FC<Props> = ({ setSidebarContent, landscape, assessments 
 
   const onGroupClick = (group: IGroup) => {
     findGroup(group.fullyQualifiedIdentifier);
-    setSidebarContent(<Group group={group} sticky={true} />);
+    setSidebarContent(<Group defaultGroup={group} sticky={true} />);
   };
 
   if (landscape && assessments)

--- a/src/main/app/src/Components/Landscape/Dashboard/StatusBar.tsx
+++ b/src/main/app/src/Components/Landscape/Dashboard/StatusBar.tsx
@@ -53,7 +53,7 @@ const StatusBar: React.FC<Props> = ({ setSidebarContent, landscape, assessments 
 
   const onGroupClick = (group: IGroup) => {
     findGroup(group.fullyQualifiedIdentifier);
-    setSidebarContent(<Group defaultGroup={group} sticky={true} />);
+    setSidebarContent(<Group initialGroup={group} sticky={true} />);
   };
 
   if (landscape && assessments)

--- a/src/main/app/src/Components/Landscape/Map/Map.tsx
+++ b/src/main/app/src/Components/Landscape/Map/Map.tsx
@@ -185,7 +185,6 @@ const Map: React.FC<Props> = ({ setPageTitle }) => {
     if (source && target && dataTarget) {
       const mapRelation = (
         <MapRelation
-          dataSource={dataSource}
           defaultSource={source}
           target={target}
           key={`relation_${source.fullyQualifiedIdentifier + ';' + dataTarget}_${Math.random()}`}

--- a/src/main/app/src/Components/Landscape/Map/Map.tsx
+++ b/src/main/app/src/Components/Landscape/Map/Map.tsx
@@ -183,14 +183,12 @@ const Map: React.FC<Props> = ({ setPageTitle }) => {
     }
 
     if (source && target && dataTarget) {
-      const relId = source.fullyQualifiedIdentifier + ';' + dataTarget;
       const mapRelation = (
         <MapRelation
-          relId={relId}
           dataSource={dataSource}
           defaultSource={source}
           target={target}
-          key={`relation_${relId}_${Math.random()}`}
+          key={`relation_${source.fullyQualifiedIdentifier + ';' + dataTarget}_${Math.random()}`}
         />
       );
       // @ts-ignore

--- a/src/main/app/src/Components/Landscape/Map/Map.tsx
+++ b/src/main/app/src/Components/Landscape/Map/Map.tsx
@@ -136,7 +136,7 @@ const Map: React.FC<Props> = ({ setPageTitle }) => {
       let group = getGroup(landscapeContext.landscape, fqi);
       if (group) {
         // @ts-ignore
-        setSidebarContent(<Group group={group} key={`group_${fqi}_${Math.random()}`} />);
+        setSidebarContent(<Group defaultGroup={group} key={`group_${fqi}_${Math.random()}`} />);
       }
     }
   };
@@ -184,11 +184,11 @@ const Map: React.FC<Props> = ({ setPageTitle }) => {
 
     if (source && target && dataTarget) {
       const relId = source.fullyQualifiedIdentifier + ';' + dataTarget;
-      let relation = source.relations[relId];
       const mapRelation = (
         <MapRelation
-          relation={relation}
-          source={source}
+          relId={relId}
+          dataSource={dataSource}
+          defaultSource={source}
           target={target}
           key={`relation_${relId}_${Math.random()}`}
         />

--- a/src/main/app/src/Components/Landscape/Map/Map.tsx
+++ b/src/main/app/src/Components/Landscape/Map/Map.tsx
@@ -136,7 +136,7 @@ const Map: React.FC<Props> = ({ setPageTitle }) => {
       let group = getGroup(landscapeContext.landscape, fqi);
       if (group) {
         // @ts-ignore
-        setSidebarContent(<Group defaultGroup={group} key={`group_${fqi}_${Math.random()}`} />);
+        setSidebarContent(<Group initialGroup={group} key={`group_${fqi}_${Math.random()}`} />);
       }
     }
   };
@@ -185,7 +185,7 @@ const Map: React.FC<Props> = ({ setPageTitle }) => {
     if (source && target && dataTarget) {
       const mapRelation = (
         <MapRelation
-          defaultSource={source}
+          initialSource={source}
           target={target}
           key={`relation_${source.fullyQualifiedIdentifier + ';' + dataTarget}_${Math.random()}`}
         />

--- a/src/main/app/src/Components/Landscape/Map/MapRelation/MapRelation.test.tsx
+++ b/src/main/app/src/Components/Landscape/Map/MapRelation/MapRelation.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import MapRelation from './MapRelation';
 
 it('should render mapRelation component', () => {
@@ -8,7 +8,6 @@ it('should render mapRelation component', () => {
     name: 'fooName',
     owner: '',
     contact: '',
-    relations: {},
     labels: {},
     tags: [],
     icon: '',
@@ -16,6 +15,17 @@ it('should render mapRelation component', () => {
     fullyQualifiedIdentifier: 'abc/foo',
     group: 'Customers',
     networks: ['lan'],
+    relations: {
+      'abc/foo;abc/bar': {
+        source: 'abc/foo',
+        target: 'abc/bar',
+        type: 'PROVIDER',
+        id: 'abc/bar',
+        direction: 'outbound',
+        name: 'bar',
+        labels: {},
+      },
+    },
   };
   const target = {
     identifier: 'bar',
@@ -32,21 +42,20 @@ it('should render mapRelation component', () => {
     networks: ['vpn', 'lan'],
   };
 
-  const relation = {
-    source: source.fullyQualifiedIdentifier,
-    target: target.fullyQualifiedIdentifier,
-    type: 'PROVIDER',
-    id: target.fullyQualifiedIdentifier,
-    direction: 'outbound',
-    name: 'bar',
-    labels: {},
-  };
-  const { getByText, getByTestId } = render(
-    <MapRelation source={source} target={target} relation={relation} />
-  );
-  expect(getByText('fooName')).toBeInTheDocument();
-  expect(getByText('barName')).toBeInTheDocument();
-  expect(getByText('Type')).toBeInTheDocument();
-  expect(getByText('PROVIDER')).toBeInTheDocument();
-  expect(getByTestId('InfoIconRelation')).toBeInTheDocument();
+  act(() => {
+    const { getByText, getByTestId } = render(
+      <MapRelation
+        defaultSource={source}
+        dataSource={''}
+        target={target}
+        relId={source.fullyQualifiedIdentifier + ';' + target.fullyQualifiedIdentifier}
+      />
+    );
+
+    expect(getByText('fooName')).toBeInTheDocument();
+    expect(getByText('barName')).toBeInTheDocument();
+    expect(getByText('Type')).toBeInTheDocument();
+    expect(getByText('PROVIDER')).toBeInTheDocument();
+    expect(getByTestId('InfoIconRelation')).toBeInTheDocument();
+  });
 });

--- a/src/main/app/src/Components/Landscape/Map/MapRelation/MapRelation.test.tsx
+++ b/src/main/app/src/Components/Landscape/Map/MapRelation/MapRelation.test.tsx
@@ -45,7 +45,7 @@ it('should render mapRelation component', () => {
   act(() => {
     const { getByText, getByTestId } = render(
       <MapRelation
-        defaultSource={source}
+        initialSource={source}
         target={target}
       />
     );

--- a/src/main/app/src/Components/Landscape/Map/MapRelation/MapRelation.test.tsx
+++ b/src/main/app/src/Components/Landscape/Map/MapRelation/MapRelation.test.tsx
@@ -48,7 +48,6 @@ it('should render mapRelation component', () => {
         defaultSource={source}
         dataSource={''}
         target={target}
-        relId={source.fullyQualifiedIdentifier + ';' + target.fullyQualifiedIdentifier}
       />
     );
 

--- a/src/main/app/src/Components/Landscape/Map/MapRelation/MapRelation.test.tsx
+++ b/src/main/app/src/Components/Landscape/Map/MapRelation/MapRelation.test.tsx
@@ -46,7 +46,6 @@ it('should render mapRelation component', () => {
     const { getByText, getByTestId } = render(
       <MapRelation
         defaultSource={source}
-        dataSource={''}
         target={target}
       />
     );

--- a/src/main/app/src/Components/Landscape/Map/MapRelation/MapRelation.tsx
+++ b/src/main/app/src/Components/Landscape/Map/MapRelation/MapRelation.tsx
@@ -24,7 +24,6 @@ interface Props {
   dataSource: string | null;
   defaultSource: IItem;
   target: IItem;
-  relId: string;
 }
 
 /**
@@ -32,13 +31,15 @@ interface Props {
  * Returns a chosen Map Relation
  *
  */
-const MapRelation: React.FC<Props> = ({ dataSource, defaultSource, target, relId }) => {
+const MapRelation: React.FC<Props> = ({ dataSource, defaultSource, target }) => {
   const classes = componentStyles();
   const theme = useTheme();
 
+
   const [visible, setVisible] = useState<boolean>(true);
-  const [relation, setRelation] = useState<IRelation>(defaultSource.relations[relId]);
   const [source, setSource] = useState<IItem>(defaultSource);
+  const relId = source.fullyQualifiedIdentifier + ";" + target.fullyQualifiedIdentifier;
+  const [relation, setRelation] = useState<IRelation>(defaultSource.relations[relId]);
   const locateFunctionContext = useContext(LocateFunctionContext);
   const landscapeContext = useContext(LandscapeContext);
 

--- a/src/main/app/src/Components/Landscape/Map/MapRelation/MapRelation.tsx
+++ b/src/main/app/src/Components/Landscape/Map/MapRelation/MapRelation.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import {
   Card,
   CardHeader,
@@ -17,13 +17,14 @@ import componentStyles from '../../../../Resources/styling/ComponentStyles';
 import ItemAvatar from '../../Modals/Item/ItemAvatar';
 import { Close, InfoOutlined } from '@material-ui/icons';
 import { LandscapeContext } from '../../../../Context/LandscapeContext';
-import { getLabels } from '../../Utils/utils';
+import { getItem, getLabels } from '../../Utils/utils';
 import MappedString from '../../Utils/MappedString';
 
 interface Props {
-  source: IItem;
+  dataSource: string | null;
+  defaultSource: IItem;
   target: IItem;
-  relation: IRelation;
+  relId: string;
 }
 
 /**
@@ -31,13 +32,26 @@ interface Props {
  * Returns a chosen Map Relation
  *
  */
-const MapRelation: React.FC<Props> = ({ source, target, relation }) => {
+const MapRelation: React.FC<Props> = ({ dataSource, defaultSource, target, relId }) => {
   const classes = componentStyles();
   const theme = useTheme();
 
   const [visible, setVisible] = useState<boolean>(true);
+  const [relation, setRelation] = useState<IRelation>(defaultSource.relations[relId]);
+  const [source, setSource] = useState<IItem>(defaultSource);
   const locateFunctionContext = useContext(LocateFunctionContext);
   const landscapeContext = useContext(LandscapeContext);
+
+  useEffect(() => {
+    if (!landscapeContext.landscape) {
+      return;
+    }
+    if (!dataSource) {
+      return;
+    }
+    setSource(getItem(landscapeContext.landscape, dataSource) || source);
+    setRelation(source.relations[relId]);
+  }, [landscapeContext.landscape, dataSource, relId, source]);
 
   if (!visible) return null;
 

--- a/src/main/app/src/Components/Landscape/Map/MapRelation/MapRelation.tsx
+++ b/src/main/app/src/Components/Landscape/Map/MapRelation/MapRelation.tsx
@@ -21,7 +21,6 @@ import { getItem, getLabels } from '../../Utils/utils';
 import MappedString from '../../Utils/MappedString';
 
 interface Props {
-  dataSource: string | null;
   defaultSource: IItem;
   target: IItem;
 }
@@ -31,23 +30,20 @@ interface Props {
  * Returns a chosen Map Relation
  *
  */
-const MapRelation: React.FC<Props> = ({ dataSource, defaultSource, target }) => {
+const MapRelation: React.FC<Props> = ({ defaultSource, target }) => {
   const classes = componentStyles();
   const theme = useTheme();
-
 
   const [visible, setVisible] = useState<boolean>(true);
   const [source, setSource] = useState<IItem>(defaultSource);
   const relId = source.fullyQualifiedIdentifier + ";" + target.fullyQualifiedIdentifier;
+  const dataSource = defaultSource.fullyQualifiedIdentifier;
   const [relation, setRelation] = useState<IRelation>(defaultSource.relations[relId]);
   const locateFunctionContext = useContext(LocateFunctionContext);
   const landscapeContext = useContext(LandscapeContext);
 
   useEffect(() => {
     if (!landscapeContext.landscape) {
-      return;
-    }
-    if (!dataSource) {
       return;
     }
     setSource(getItem(landscapeContext.landscape, dataSource) || source);

--- a/src/main/app/src/Components/Landscape/Map/MapRelation/MapRelation.tsx
+++ b/src/main/app/src/Components/Landscape/Map/MapRelation/MapRelation.tsx
@@ -47,11 +47,7 @@ const MapRelation: React.FC<Props> = ({ defaultSource, target }) => {
       return;
     }
     setSource(getItem(landscapeContext.landscape, dataSource) || source);
-    if (source.relations[relId]) {
-      setRelation(source.relations[relId]);
-    } else {
-      setVisible(false);
-    }
+    source.relations[relId] ? setRelation(source.relations[relId]) : setVisible(false);
   }, [landscapeContext.landscape, dataSource, relId, source]);
 
   if (!visible) return null;

--- a/src/main/app/src/Components/Landscape/Map/MapRelation/MapRelation.tsx
+++ b/src/main/app/src/Components/Landscape/Map/MapRelation/MapRelation.tsx
@@ -36,7 +36,7 @@ const MapRelation: React.FC<Props> = ({ defaultSource, target }) => {
 
   const [visible, setVisible] = useState<boolean>(true);
   const [source, setSource] = useState<IItem>(defaultSource);
-  const relId = source.fullyQualifiedIdentifier + ";" + target.fullyQualifiedIdentifier;
+  const relId = source.fullyQualifiedIdentifier + ';' + target.fullyQualifiedIdentifier;
   const dataSource = defaultSource.fullyQualifiedIdentifier;
   const [relation, setRelation] = useState<IRelation>(defaultSource.relations[relId]);
   const locateFunctionContext = useContext(LocateFunctionContext);
@@ -47,7 +47,11 @@ const MapRelation: React.FC<Props> = ({ defaultSource, target }) => {
       return;
     }
     setSource(getItem(landscapeContext.landscape, dataSource) || source);
-    setRelation(source.relations[relId]);
+    if (source.relations[relId]) {
+      setRelation(source.relations[relId]);
+    } else {
+      setVisible(false);
+    }
   }, [landscapeContext.landscape, dataSource, relId, source]);
 
   if (!visible) return null;

--- a/src/main/app/src/Components/Landscape/Map/MapRelation/MapRelation.tsx
+++ b/src/main/app/src/Components/Landscape/Map/MapRelation/MapRelation.tsx
@@ -21,7 +21,7 @@ import { getItem, getLabels } from '../../Utils/utils';
 import MappedString from '../../Utils/MappedString';
 
 interface Props {
-  defaultSource: IItem;
+  initialSource: IItem;
   target: IItem;
 }
 
@@ -30,15 +30,15 @@ interface Props {
  * Returns a chosen Map Relation
  *
  */
-const MapRelation: React.FC<Props> = ({ defaultSource, target }) => {
+const MapRelation: React.FC<Props> = ({ initialSource, target }) => {
   const classes = componentStyles();
   const theme = useTheme();
 
   const [visible, setVisible] = useState<boolean>(true);
-  const [source, setSource] = useState<IItem>(defaultSource);
+  const [source, setSource] = useState<IItem>(initialSource);
   const relId = source.fullyQualifiedIdentifier + ';' + target.fullyQualifiedIdentifier;
-  const dataSource = defaultSource.fullyQualifiedIdentifier;
-  const [relation, setRelation] = useState<IRelation>(defaultSource.relations[relId]);
+  const dataSource = initialSource.fullyQualifiedIdentifier;
+  const [relation, setRelation] = useState<IRelation>(initialSource.relations[relId]);
   const locateFunctionContext = useContext(LocateFunctionContext);
   const landscapeContext = useContext(LandscapeContext);
 

--- a/src/main/app/src/Components/Landscape/Modals/Group/Group.test.tsx
+++ b/src/main/app/src/Components/Landscape/Modals/Group/Group.test.tsx
@@ -11,6 +11,6 @@ it('should render landscape group component', () => {
     icon: 'foo.png',
   };
 
-  const { getByText } = render(<Group defaultGroup={group} />);
+  const { getByText } = render(<Group initialGroup={group} />);
   expect(getByText('foo')).toBeInTheDocument();
 });

--- a/src/main/app/src/Components/Landscape/Modals/Group/Group.test.tsx
+++ b/src/main/app/src/Components/Landscape/Modals/Group/Group.test.tsx
@@ -11,6 +11,6 @@ it('should render landscape group component', () => {
     icon: 'foo.png',
   };
 
-  const { getByText } = render(<Group group={group} />);
+  const { getByText } = render(<Group defaultGroup={group} />);
   expect(getByText('foo')).toBeInTheDocument();
 });

--- a/src/main/app/src/Components/Landscape/Modals/Group/Group.tsx
+++ b/src/main/app/src/Components/Landscape/Modals/Group/Group.tsx
@@ -1,7 +1,7 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 
 import { IGroup } from '../../../../interfaces';
-import { getLabels, getLinks } from '../../Utils/utils';
+import { getGroup, getLabels, getLinks } from '../../Utils/utils';
 import { Card, CardHeader } from '@material-ui/core';
 import CardContent from '@material-ui/core/CardContent';
 import StatusChip from '../../../StatusChip/StatusChip';
@@ -16,18 +16,19 @@ import { LandscapeContext } from '../../../../Context/LandscapeContext';
 import { Close } from '@material-ui/icons';
 
 interface Props {
-  group: IGroup;
+  defaultGroup: IGroup;
   sticky?: boolean;
 }
 
 /**
  * Returns a chosen group if information is available
  */
-const Group: React.FC<Props> = ({ group, sticky }) => {
+const Group: React.FC<Props> = ({ defaultGroup, sticky }) => {
   const componentClasses = componentStyles();
   const landscapeContext = useContext(LandscapeContext);
   const locateFunctionContext = useContext(LocateFunctionContext);
   const [visible, setVisible] = useState<boolean>(true);
+  const [group, setGroup] = useState<IGroup>(defaultGroup);
 
   const getGroupItems = (
     group: IGroup,
@@ -59,6 +60,14 @@ const Group: React.FC<Props> = ({ group, sticky }) => {
     }
     return [];
   };
+
+  useEffect(() => {
+    if (landscapeContext.landscape) {
+      setGroup(
+        getGroup(landscapeContext.landscape, defaultGroup.fullyQualifiedIdentifier) || defaultGroup
+      );
+    }
+  }, [landscapeContext.landscape, defaultGroup]);
 
   if (!visible) return null;
 
@@ -105,10 +114,10 @@ const Group: React.FC<Props> = ({ group, sticky }) => {
             {group?.description ? `${group?.description}` : ''}
           </span>
           {group?.contact ? (
-            <span className='contact group'>
+            <div className='contact group'>
               <span className='label'>Contact: </span>
               {group?.contact || 'No Contact provided'}
-            </span>
+            </div>
           ) : null}
           <div className='owner group'>
             <span className='label'>Owner: </span>

--- a/src/main/app/src/Components/Landscape/Modals/Group/Group.tsx
+++ b/src/main/app/src/Components/Landscape/Modals/Group/Group.tsx
@@ -63,9 +63,12 @@ const Group: React.FC<Props> = ({ defaultGroup, sticky }) => {
 
   useEffect(() => {
     if (landscapeContext.landscape) {
-      setGroup(
-        getGroup(landscapeContext.landscape, defaultGroup.fullyQualifiedIdentifier) || defaultGroup
-      );
+      const newGroup = getGroup(landscapeContext.landscape, defaultGroup.fullyQualifiedIdentifier);
+      if (newGroup) {
+        newGroup.items.length > 0 ? setGroup(newGroup) : setVisible(false);
+      } else {
+        setVisible(false);
+      }
     }
   }, [landscapeContext.landscape, defaultGroup]);
 

--- a/src/main/app/src/Components/Landscape/Modals/Group/Group.tsx
+++ b/src/main/app/src/Components/Landscape/Modals/Group/Group.tsx
@@ -16,19 +16,19 @@ import { LandscapeContext } from '../../../../Context/LandscapeContext';
 import { Close } from '@material-ui/icons';
 
 interface Props {
-  defaultGroup: IGroup;
+  initialGroup: IGroup;
   sticky?: boolean;
 }
 
 /**
  * Returns a chosen group if information is available
  */
-const Group: React.FC<Props> = ({ defaultGroup, sticky }) => {
+const Group: React.FC<Props> = ({ initialGroup, sticky }) => {
   const componentClasses = componentStyles();
   const landscapeContext = useContext(LandscapeContext);
   const locateFunctionContext = useContext(LocateFunctionContext);
   const [visible, setVisible] = useState<boolean>(true);
-  const [group, setGroup] = useState<IGroup>(defaultGroup);
+  const [group, setGroup] = useState<IGroup>(initialGroup);
 
   const getGroupItems = (
     group: IGroup,
@@ -63,14 +63,14 @@ const Group: React.FC<Props> = ({ defaultGroup, sticky }) => {
 
   useEffect(() => {
     if (landscapeContext.landscape) {
-      const newGroup = getGroup(landscapeContext.landscape, defaultGroup.fullyQualifiedIdentifier);
+      const newGroup = getGroup(landscapeContext.landscape, initialGroup.fullyQualifiedIdentifier);
       if (newGroup) {
         newGroup.items.length > 0 ? setGroup(newGroup) : setVisible(false);
       } else {
         setVisible(false);
       }
     }
-  }, [landscapeContext.landscape, defaultGroup]);
+  }, [landscapeContext.landscape, initialGroup]);
 
   if (!visible) return null;
 

--- a/src/main/app/src/Components/Landscape/Modals/Group/Group.tsx
+++ b/src/main/app/src/Components/Landscape/Modals/Group/Group.tsx
@@ -116,15 +116,13 @@ const Group: React.FC<Props> = ({ initialGroup, sticky }) => {
           <span className='description group'>
             {group?.description ? `${group?.description}` : ''}
           </span>
-          {group?.contact ? (
-            <div className='contact group'>
-              <span className='label'>Contact: </span>
-              {group?.contact || 'No Contact provided'}
-            </div>
-          ) : null}
           <div className='owner group'>
             <span className='label'>Owner: </span>
             {group?.owner || 'No Owner provided'}
+          </div>
+          <div className='contact group'>
+            <span className='label'>Contact: </span>
+            {group?.contact || 'No Contact provided'}
           </div>
         </div>
 

--- a/src/main/app/src/Components/Landscape/Modals/Item/Item.test.tsx
+++ b/src/main/app/src/Components/Landscape/Modals/Item/Item.test.tsx
@@ -55,7 +55,7 @@ describe('<Item />', () => {
     mock.mockReturnValue(Promise.resolve(useItem));
 
     //when
-    const { container, getByText } = render(<Item fullyQualifiedItemIdentifier={'foo'} />);
+    const { getByText } = render(<Item fullyQualifiedItemIdentifier={'foo'} />);
 
     //then
     await waitFor(() => expect(mock).toHaveBeenCalledTimes(1));

--- a/src/main/app/src/Components/Landscape/Modals/Item/Item.tsx
+++ b/src/main/app/src/Components/Landscape/Modals/Item/Item.tsx
@@ -205,9 +205,16 @@ const Item: React.FC<Props> = ({ fullyQualifiedItemIdentifier, small, sticky }) 
 
   useEffect(() => {
     if (fullyQualifiedItemIdentifier) {
-      get(`/api/${fullyQualifiedItemIdentifier}`).then((loaded) => {
-        setItem(loaded);
-      });
+      get(`/api/${fullyQualifiedItemIdentifier}`)
+        .then((loaded) => {
+          setItem(loaded);
+        })
+        .catch((error) => {
+          // Make the component invisible if api can't find an item
+          if (error.response.status === 404) {
+            setVisible(false);
+          }
+        });
     }
   }, [landscapeContext.landscape, fullyQualifiedItemIdentifier]);
 

--- a/src/main/app/src/Components/Landscape/Modals/Item/Item.tsx
+++ b/src/main/app/src/Components/Landscape/Modals/Item/Item.tsx
@@ -204,12 +204,12 @@ const Item: React.FC<Props> = ({ fullyQualifiedItemIdentifier, small, sticky }) 
   };
 
   useEffect(() => {
-    if (!item && fullyQualifiedItemIdentifier) {
+    if (fullyQualifiedItemIdentifier) {
       get(`/api/${fullyQualifiedItemIdentifier}`).then((loaded) => {
         setItem(loaded);
       });
     }
-  }, [item, fullyQualifiedItemIdentifier]);
+  }, [landscapeContext.landscape, fullyQualifiedItemIdentifier]);
 
   useEffect(() => {
     if (small) {
@@ -260,7 +260,11 @@ const Item: React.FC<Props> = ({ fullyQualifiedItemIdentifier, small, sticky }) 
                     'A PROVIDER relation is a hard dependency that is required. A DATAFLOW relation is a soft dependency.'
                   }
                 >
-                  <InfoOutlined style={{ color: theme.palette.info.main }} fontSize='small' data-testid={'InfoIcon'} />
+                  <InfoOutlined
+                    style={{ color: theme.palette.info.main }}
+                    fontSize='small'
+                    data-testid={'InfoIcon'}
+                  />
                 </span>
               </>
             }

--- a/src/main/app/src/Components/Landscape/Search/Search.test.tsx
+++ b/src/main/app/src/Components/Landscape/Search/Search.test.tsx
@@ -70,7 +70,7 @@ describe('<Search />', () => {
   it('should add facet to search term', async () => {
     const mock = jest.spyOn(APIClient, 'get');
     mock.mockReturnValue(Promise.resolve(facets));
-    const { container, getByText, getByDisplayValue } = render(
+    const { container, getByText } = render(
       <LandscapeContext.Provider value={landscapeContextValue}>
         <MockTheme>
           <Search searchTerm={''} setSearchTerm={() => {}} />

--- a/src/main/app/src/Context/LandscapeContext.tsx
+++ b/src/main/app/src/Context/LandscapeContext.tsx
@@ -98,17 +98,16 @@ const LandscapeContextProvider: React.FC = (props) => {
   }, [client, subscriptions]);
 
   /**
-   * Load the landscape data when the identifier changes.
+   * Load the landscape data when the identifier or landscape changes.
    */
   useEffect(() => {
     if (identifier == null) return;
-
     get(`/api/${identifier}`).then((response) => {
       setLandscape(response);
       console.debug(`Loaded landscape data after identifier change: ${identifier}`);
     });
     setLandscapeChanges(null);
-  }, [identifier]);
+  }, [identifier, landscapeChanges]);
 
   /**
    * Load the landscape and assessment data when the identifier changes.


### PR DESCRIPTION
Fixed reloading of landscape data in:
- Item.tsx
- MapRelation.tsx
- Group.tsx

They reload their data now if a change to landscapeContext.landscape occurs. If no more data is accessible because it has been deleted and the corresponding window is still open, it will now close itself.
Landscape changes will now trigger an api request to refresh the landscape data.